### PR TITLE
feat: add timing/polling observability with test coverage

### DIFF
--- a/src/__tests__/agents/spawner-timing.test.ts
+++ b/src/__tests__/agents/spawner-timing.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentConfig } from "../../types/agents.js";
+import type { HiveMindConfig } from "../../config/schema.js";
+import { getDefaultConfig } from "../../config/loader.js";
+
+// Mock shell.js — spawnClaude is the real dependency
+vi.mock("../../utils/shell.js", () => ({
+  spawnClaude: vi.fn(),
+  runShell: vi.fn(),
+}));
+
+// Mock file-io.js — fileExists check after spawn
+vi.mock("../../utils/file-io.js", () => ({
+  fileExists: vi.fn(() => true),
+  readFileSafe: vi.fn(() => ""),
+  ensureDir: vi.fn(),
+  writeFileAtomic: vi.fn(),
+}));
+
+// Mock prompts.js — buildPrompt
+vi.mock("../../agents/prompts.js", () => ({
+  buildPrompt: vi.fn(() => "mocked prompt"),
+  getAgentRules: vi.fn(() => []),
+}));
+
+// Mock tool-permissions.js — getToolsForAgent
+vi.mock("../../agents/tool-permissions.js", () => ({
+  getToolsForAgent: vi.fn(() => ["Read", "Write"]),
+}));
+
+const defaultConfig: HiveMindConfig = getDefaultConfig();
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    type: "researcher",
+    model: "sonnet",
+    inputFiles: [],
+    outputFile: "/tmp/test-output.md",
+    rules: [],
+    memoryContent: "",
+    ...overrides,
+  };
+}
+
+describe("spawner timing", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("logs per-agent timing with duration", async () => {
+    const { spawnClaude } = await import("../../utils/shell.js");
+    vi.mocked(spawnClaude).mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+      json: {
+        result: "done",
+        cost_usd: 0.05,
+        model: "sonnet",
+        session_id: "sess-1",
+        duration_ms: 12000,
+        raw: {},
+      },
+      killedByOutputDetection: false,
+    });
+
+    const { spawnAgent } = await import("../../agents/spawner.js");
+    await spawnAgent(makeConfig({ type: "researcher" }), defaultConfig);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    const logs: string[] = consoleSpy.mock.calls.map((c: any[]) => String(c[0]));
+    expect(logs.some((l) => l.includes("[agent:researcher] completed in 12.0s"))).toBe(true);
+    expect(logs.some((l) => l.includes("(killed by output detection)"))).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("logs kill flag when killedByOutputDetection is true", async () => {
+    const { spawnClaude } = await import("../../utils/shell.js");
+    vi.mocked(spawnClaude).mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+      json: {
+        result: "done",
+        cost_usd: 0.03,
+        model: "sonnet",
+        session_id: "sess-2",
+        duration_ms: 8000,
+        raw: {},
+      },
+      killedByOutputDetection: true,
+    });
+
+    const { spawnAgent } = await import("../../agents/spawner.js");
+    await spawnAgent(makeConfig({ type: "critic" }), defaultConfig);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    const logs: string[] = consoleSpy.mock.calls.map((c: any[]) => String(c[0]));
+    expect(logs.some((l) => l.includes("[agent:critic] completed in 8.0s"))).toBe(true);
+    expect(logs.some((l) => l.includes("(killed by output detection)"))).toBe(true);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("returns killedByOutputDetection in AgentResult", async () => {
+    const { spawnClaude } = await import("../../utils/shell.js");
+    vi.mocked(spawnClaude).mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+      json: {
+        result: "done",
+        cost_usd: 0.03,
+        model: "sonnet",
+        session_id: "sess-3",
+        duration_ms: 8000,
+        raw: {},
+      },
+      killedByOutputDetection: true,
+    });
+
+    const { spawnAgent } = await import("../../agents/spawner.js");
+    const result = await spawnAgent(makeConfig({ type: "critic" }), defaultConfig);
+
+    expect(result.killedByOutputDetection).toBe(true);
+    expect(result.durationMs).toBe(8000);
+    expect(result.costUsd).toBe(0.03);
+    expect(result.success).toBe(true);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/__tests__/e2e/timing-smoke.test.ts
+++ b/src/__tests__/e2e/timing-smoke.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync, existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getDefaultConfig } from "../../config/loader.js";
+import type { PipelineDirs } from "../../types/pipeline-dirs.js";
+
+// Track spawn calls
+const spawnCalls: Array<{ type: string; outputFile: string }> = [];
+
+let callIdx = 0;
+const DURATIONS = [8000, 12000, 15000, 6000, 20000, 10000, 5000, 14000, 9000, 11000];
+
+vi.mock("../../agents/spawner.js", () => {
+  const mockSpawn = async (config: { outputFile: string; type: string }) => {
+    const { writeFileSync: wf, mkdirSync: md } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    md(dirname(config.outputFile), { recursive: true });
+
+    if (config.type === "planner") {
+      wf(config.outputFile, JSON.stringify({
+        schemaVersion: "2.0.0",
+        prdPath: "PRD.md",
+        specPath: "spec/SPEC-v1.0.md",
+        stories: [{
+          id: "US-01",
+          title: "Setup",
+          specSections: ["§1"],
+          dependencies: [],
+          sourceFiles: [{ path: "package.json", changeType: "ADDED" }],
+          complexity: "low",
+          rolesUsed: ["analyst"],
+          stepFile: "plans/steps/US-01.md",
+          status: "not-started",
+          attempts: 0,
+          maxAttempts: 3,
+          committed: false,
+          commitHash: null,
+        }],
+      }));
+    } else {
+      wf(config.outputFile, `# Mock output for ${config.type}`);
+    }
+
+    spawnCalls.push({ type: config.type, outputFile: config.outputFile });
+    const dur = DURATIONS[callIdx++ % DURATIONS.length];
+    return { success: true, outputFile: config.outputFile, costUsd: 0.05, durationMs: dur };
+  };
+
+  return {
+    spawnAgentWithRetry: vi.fn(mockSpawn),
+    spawnAgent: vi.fn(async () => ({ success: true, outputFile: "" })),
+    spawnAgentsParallel: vi.fn(async (configs: { outputFile: string; type: string }[]) => {
+      return Promise.all(configs.map(mockSpawn));
+    }),
+  };
+});
+
+vi.mock("../../stages/baseline-check.js", () => ({
+  runBaselineCheck: vi.fn(async () => ({ passed: true, buildOutput: "", testOutput: "" })),
+}));
+
+const config = getDefaultConfig();
+
+describe("timing smoke test", () => {
+  let testDir: string;
+  let prdPath: string;
+  let dirs: PipelineDirs;
+
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    callIdx = 0;
+
+    testDir = join(process.cwd(), ".test-timing-smoke");
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+
+    prdPath = join(testDir, "PRD.md");
+    writeFileSync(prdPath, "# Test PRD\nBuild a timing test.");
+
+    dirs = {
+      workingDir: join(testDir, ".hive-mind"),
+      knowledgeDir: join(testDir, ".hive-mind"),
+      labDir: join(testDir, ".hive-mind"),
+    };
+  });
+
+  it("--stop-after-plan produces timing summary and report", async () => {
+    const { runPipeline } = await import("../../orchestrator.js");
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // AC#6: Pipeline should not throw
+    await runPipeline(prdPath, dirs, config, {
+      skipNormalize: true,
+      stopAfterPlan: true,
+    });
+
+    const logs = consoleSpy.mock.calls.map((c) => String(c[0]));
+
+    // AC#4: No timeouts
+    expect(logs.some((l) => l.includes("[spawnClaude] Timed out"))).toBe(false);
+
+    // AC#7: Timing summary printed
+    expect(logs.some((l) => l.includes("Timing summary"))).toBe(true);
+    expect(logs.some((l) => l.includes("Fastest:"))).toBe(true);
+    expect(logs.some((l) => l.includes("Median:"))).toBe(true);
+    expect(logs.some((l) => l.includes("Slowest:"))).toBe(true);
+
+    // AC#5: Spec files exist
+    const specDir = join(dirs.workingDir, "spec");
+    expect(existsSync(specDir)).toBe(true);
+    const specFiles = readdirSync(specDir).filter((f) => f.endsWith(".md"));
+    expect(specFiles.length).toBeGreaterThanOrEqual(1);
+
+    // AC#5: Execution plan exists
+    const planFile = join(dirs.workingDir, "plans", "execution-plan.json");
+    expect(existsSync(planFile)).toBe(true);
+
+    // AC#8: Timing report written
+    const reportPath = join(dirs.workingDir, "timing-report.md");
+    expect(existsSync(reportPath)).toBe(true);
+    const reportContent = readFileSync(reportPath, "utf-8");
+    expect(reportContent).toContain("# Agent Timing Report");
+    expect(reportContent).toContain("|");
+
+    consoleSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/utils/cost-tracker.test.ts
+++ b/src/__tests__/utils/cost-tracker.test.ts
@@ -85,6 +85,63 @@ describe("CostTracker", () => {
     expect(() => tracker.enforceBudget()).not.toThrow();
   });
 
+  describe("getTimingSummary", () => {
+    it("returns correct fastest/median/slowest", () => {
+      const tracker = new CostTracker();
+      tracker.recordAgentCost("SPEC", "critic", 0.01, 5000);
+      tracker.recordAgentCost("SPEC", "researcher", 0.03, 10000);
+      tracker.recordAgentCost("PLAN", "planner", 0.05, 12000);
+      tracker.recordAgentCost("SPEC", "spec-drafter", 0.04, 15000);
+      tracker.recordAgentCost("SPEC", "spec-corrector", 0.02, 20000);
+
+      const timing = tracker.getTimingSummary();
+      expect(timing.agentCount).toBe(5);
+      expect(timing.fastest).toEqual({ agentType: "critic", storyId: "SPEC", durationMs: 5000 });
+      // Math.floor(5/2) = 2 → index 2 in sorted array → planner at 12000
+      expect(timing.median).toEqual({ agentType: "planner", storyId: "PLAN", durationMs: 12000 });
+      expect(timing.slowest).toEqual({ agentType: "spec-corrector", storyId: "SPEC", durationMs: 20000 });
+      expect(timing.totalDurationMs).toBe(62000);
+    });
+
+    it("filters out entries with durationMs === 0", () => {
+      const tracker = new CostTracker();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      tracker.recordAgentCost("SPEC", "researcher", 0.03, 10000);
+      tracker.recordAgentCost("SPEC", "critic", undefined, 0);
+
+      const timing = tracker.getTimingSummary();
+      expect(timing.agentCount).toBe(1);
+      expect(timing.fastest!.agentType).toBe("researcher");
+      warnSpy.mockRestore();
+    });
+
+    it("returns nulls when no entries have positive duration", () => {
+      const tracker = new CostTracker();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      tracker.recordAgentCost("SPEC", "researcher", undefined, 0);
+      tracker.recordAgentCost("SPEC", "critic", undefined, 0);
+
+      const timing = tracker.getTimingSummary();
+      expect(timing.agentCount).toBe(0);
+      expect(timing.fastest).toBeNull();
+      expect(timing.median).toBeNull();
+      expect(timing.slowest).toBeNull();
+      expect(timing.totalDurationMs).toBe(0);
+      warnSpy.mockRestore();
+    });
+
+    it("handles single entry", () => {
+      const tracker = new CostTracker();
+      tracker.recordAgentCost("PLAN", "planner", 0.10, 8000);
+
+      const timing = tracker.getTimingSummary();
+      expect(timing.agentCount).toBe(1);
+      expect(timing.fastest).toEqual({ agentType: "planner", storyId: "PLAN", durationMs: 8000 });
+      expect(timing.median).toEqual({ agentType: "planner", storyId: "PLAN", durationMs: 8000 });
+      expect(timing.slowest).toEqual({ agentType: "planner", storyId: "PLAN", durationMs: 8000 });
+    });
+  });
+
   it("getSummary returns correct structure", () => {
     const tracker = new CostTracker();
     tracker.recordAgentCost("US-01", "implementer", 0.05, 5000);

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -25,6 +25,9 @@ export async function spawnAgent(
     outputFile: config.outputFile,
   });
 
+  const elapsed = result.json?.duration_ms;
+  console.log(`[agent:${config.type}] completed in ${elapsed ? `${(elapsed / 1000).toFixed(1)}s` : '?'}${result.killedByOutputDetection ? ' (killed by output detection)' : ''}`);
+
   const outputExists = fileExists(config.outputFile);
 
   // Fail only if exit code is bad AND no output file
@@ -37,6 +40,7 @@ export async function spawnAgent(
       modelUsed: result.json?.model,
       sessionId: result.json?.session_id,
       durationMs: result.json?.duration_ms,
+      killedByOutputDetection: result.killedByOutputDetection,
     };
   }
 
@@ -48,6 +52,7 @@ export async function spawnAgent(
     modelUsed: result.json?.model,
     sessionId: result.json?.session_id,
     durationMs: result.json?.duration_ms,
+    killedByOutputDetection: result.killedByOutputDetection,
   };
 }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -58,6 +58,44 @@ import { writeFileAtomic } from "./utils/file-io.js";
 import { spawnAgentWithRetry } from "./agents/spawner.js";
 import { getAgentRules } from "./agents/prompts.js";
 
+function printTimingSummary(tracker: CostTracker): void {
+  const timing = tracker.getTimingSummary();
+  if (timing.agentCount > 0) {
+    console.log(`\nTiming summary (${timing.agentCount} agents, ${(timing.totalDurationMs / 1000).toFixed(1)}s total):`);
+    console.log(`  Fastest: ${timing.fastest!.agentType} (${timing.fastest!.storyId}) — ${(timing.fastest!.durationMs / 1000).toFixed(1)}s`);
+    console.log(`  Median:  ${timing.median!.agentType} (${timing.median!.storyId}) — ${(timing.median!.durationMs / 1000).toFixed(1)}s`);
+    console.log(`  Slowest: ${timing.slowest!.agentType} (${timing.slowest!.storyId}) — ${(timing.slowest!.durationMs / 1000).toFixed(1)}s`);
+  }
+}
+
+function writeTimingReport(tracker: CostTracker, workingDir: string): void {
+  const timing = tracker.getTimingSummary();
+  if (timing.agentCount === 0) return;
+
+  const lines: string[] = [
+    "# Agent Timing Report",
+    "",
+    "## Summary",
+    `- Total agents: ${timing.agentCount}`,
+    `- Total duration: ${(timing.totalDurationMs / 1000).toFixed(1)}s`,
+    `- Fastest: ${timing.fastest!.agentType} (${timing.fastest!.storyId}) — ${(timing.fastest!.durationMs / 1000).toFixed(1)}s`,
+    `- Median: ${timing.median!.agentType} (${timing.median!.storyId}) — ${(timing.median!.durationMs / 1000).toFixed(1)}s`,
+    `- Slowest: ${timing.slowest!.agentType} (${timing.slowest!.storyId}) — ${(timing.slowest!.durationMs / 1000).toFixed(1)}s`,
+    "",
+    "## All Agents (sorted by duration)",
+    "| # | Stage | Agent | Duration | Cost |",
+    "|---|-------|-------|----------|------|",
+  ];
+
+  timing.perAgent.forEach((entry, i) => {
+    lines.push(`| ${i + 1} | ${entry.storyId} | ${entry.agentType} | ${(entry.durationMs / 1000).toFixed(1)}s | $${entry.costUsd.toFixed(4)} |`);
+  });
+
+  lines.push("");
+  writeFileAtomic(join(workingDir, "timing-report.md"), lines.join("\n"));
+  console.log(`Timing report written to ${join(workingDir, "timing-report.md")}`);
+}
+
 async function safeUpdateManifest(workingDir: string): Promise<void> {
   try {
     await updateManifest(workingDir);
@@ -111,7 +149,8 @@ export async function runPipeline(
   }
 
   // skipNormalize — proceed directly to SPEC with original PRD
-  await runSpecThenCheckpoint(prdPath, dirs, config, options?.silent ?? false, options?.stopAfterPlan, options?.greenfield);
+  const tracker = new CostTracker(options?.budget);
+  await runSpecThenCheckpoint(prdPath, dirs, config, options?.silent ?? false, options?.stopAfterPlan, options?.greenfield, tracker);
 }
 
 async function runSpecThenCheckpoint(
@@ -121,9 +160,10 @@ async function runSpecThenCheckpoint(
   silent: boolean,
   stopAfterPlan?: boolean,
   greenfield?: boolean,
+  tracker?: CostTracker,
 ): Promise<void> {
   console.log("Running SPEC stage...");
-  await specStage(prdPath, dirs, config, undefined, greenfield);
+  await specStage(prdPath, dirs, config, undefined, greenfield, tracker);
   await safeUpdateManifest(dirs.workingDir);
 
   const specLogPath = join(dirs.workingDir, "manager-log.jsonl");
@@ -135,7 +175,7 @@ async function runSpecThenCheckpoint(
 
   // --stop-after-plan: auto-approve SPEC, run PLAN, print summary, exit
   if (stopAfterPlan) {
-    await runPlanStage(dirs, config, undefined, greenfield);
+    await runPlanStage(dirs, config, undefined, greenfield, tracker);
     await safeUpdateManifest(dirs.workingDir);
 
     const planFilePath = join(dirs.workingDir, "plans", "execution-plan.json");
@@ -148,6 +188,11 @@ async function runSpecThenCheckpoint(
         console.log(`  ${s.id}: ${s.title} (${fileCount} files)`);
       }
       console.log("\nPipeline stopped after PLAN. No EXECUTE agents were spawned.");
+    }
+
+    if (tracker) {
+      printTimingSummary(tracker);
+      writeTimingReport(tracker, dirs.workingDir);
     }
     return;
   }
@@ -239,7 +284,8 @@ export async function resumeFromCheckpoint(
       }
 
       // Approved — proceed to SPEC with normalized PRD
-      await runSpecThenCheckpoint(normalizedPrd, dirs, config, silent, startData.stopAfterPlan, startData.greenfield);
+      const normalizeTracker = new CostTracker(startData.budget);
+      await runSpecThenCheckpoint(normalizedPrd, dirs, config, silent, startData.stopAfterPlan, startData.greenfield, normalizeTracker);
       break;
     }
     case "approve-spec": {
@@ -311,6 +357,9 @@ export async function resumeFromCheckpoint(
           console.log(`  ${storyId}: $${cost.toFixed(4)}`);
         }
       }
+
+      printTimingSummary(tracker);
+      writeTimingReport(tracker, dirs.workingDir);
 
       // Integration verification (Phase 6 — multi-repo only)
       const planPath2 = join(dirs.workingDir, "plans", "execution-plan.json");
@@ -407,9 +456,10 @@ export async function runSpecStage(
   config: HiveMindConfig,
   feedback?: string,
   greenfield?: boolean,
+  tracker?: CostTracker,
 ): Promise<void> {
   console.log("Running SPEC stage...");
-  await specStage(prdPath, dirs, config, feedback, greenfield);
+  await specStage(prdPath, dirs, config, feedback, greenfield, tracker);
 }
 
 export async function runPlanStage(
@@ -417,9 +467,10 @@ export async function runPlanStage(
   config: HiveMindConfig,
   feedback?: string,
   greenfield?: boolean,
+  tracker?: CostTracker,
 ): Promise<void> {
   console.log("Running PLAN stage...");
-  await planStage(dirs, config, feedback, greenfield);
+  await planStage(dirs, config, feedback, greenfield, tracker);
 }
 
 export interface StoryExecutionResult {

--- a/src/stages/plan-stage.ts
+++ b/src/stages/plan-stage.ts
@@ -10,6 +10,7 @@ import { parseModules, resolveAndValidateModules } from "../utils/module-parser.
 import { loadConstitution } from "../config/loader.js";
 import type { PipelineDirs } from "../types/pipeline-dirs.js";
 import { getSourceFilePaths } from "../types/execution-plan.js";
+import type { CostTracker } from "../utils/cost-tracker.js";
 
 const ROLE_KEYWORDS: Record<string, string[]> = {
   security: [
@@ -57,6 +58,7 @@ export async function runPlanStage(
   config: HiveMindConfig,
   feedback?: string,
   greenfield?: boolean,
+  tracker?: CostTracker,
 ): Promise<void> {
   const plansDir = join(dirs.workingDir, "plans");
   const roleReportsDir = join(plansDir, "role-reports");
@@ -103,6 +105,7 @@ export async function runPlanStage(
 
   const roleReportPaths: string[] = [];
   for (let i = 0; i < roleResults.length; i++) {
+    tracker?.recordAgentCost("PLAN", roleConfigs[i].type, roleResults[i].costUsd, roleResults[i].durationMs);
     if (roleResults[i].success) {
       roleReportPaths.push(roleConfigs[i].outputFile);
     } else {
@@ -156,7 +159,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
   if (greenfield) {
     plannerRules.push(`${GREENFIELD_PLAN_BLOCK.heading}: ${GREENFIELD_PLAN_BLOCK.content}`);
   }
-  await spawnAgentWithRetry({
+  const plannerResult = await spawnAgentWithRetry({
     type: "planner",
     model: "opus",
     inputFiles: [specPath, ...roleReportPaths],
@@ -165,6 +168,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
     memoryContent: feedbackMemory,
     constitutionContent,
   }, config);
+  tracker?.recordAgentCost("PLAN", "planner", plannerResult.costUsd, plannerResult.durationMs);
 
   if (!fileExists(planJsonPath)) {
     throw new Error("Planner failed to produce execution-plan.json");
@@ -219,7 +223,10 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
     constitutionContent,
   }));
 
-  await spawnAgentsParallel(acConfigs, config);
+  const acResults = await spawnAgentsParallel(acConfigs, config);
+  for (let i = 0; i < acResults.length; i++) {
+    tracker?.recordAgentCost("PLAN", "ac-generator", acResults[i].costUsd, acResults[i].durationMs);
+  }
 
   // EC-generator per story (parallel)
   console.log(`Running ${stories.length} EC-generators in parallel...`);
@@ -233,7 +240,10 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
     constitutionContent,
   }));
 
-  await spawnAgentsParallel(ecConfigs, config);
+  const ecResults = await spawnAgentsParallel(ecConfigs, config);
+  for (let i = 0; i < ecResults.length; i++) {
+    tracker?.recordAgentCost("PLAN", "ec-generator", ecResults[i].costUsd, ecResults[i].durationMs);
+  }
 
   // Assembly: merge skeleton + ACs + ECs into final step files
   console.log("Assembling step files...");
@@ -258,7 +268,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
     if (filteredRoleReports.length === 0) continue;
 
     try {
-      await spawnAgentWithRetry({
+      const enricherResult = await spawnAgentWithRetry({
         type: "enricher",
         model: "sonnet",
         inputFiles: [stepFilePath, ...filteredRoleReports],
@@ -266,6 +276,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
         rules: getAgentRules("enricher"),
         memoryContent: feedbackMemory,
       }, config);
+      tracker?.recordAgentCost("PLAN", "enricher", enricherResult.costUsd, enricherResult.durationMs);
 
       // Validate step file still has required sections
       const enrichedContent = readFileSafe(stepFilePath);
@@ -293,7 +304,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
   if (highComplexityStories.length > 0) {
     console.log(`Running decomposer for ${highComplexityStories.length} high-complexity stories...`);
     for (const story of highComplexityStories) {
-      const subTasks = await decomposeStory(story, stepsDir, feedbackMemory, config);
+      const subTasks = await decomposeStory(story, stepsDir, feedbackMemory, config, tracker);
       if (subTasks.length > 0) {
         story.subTasks = subTasks;
         console.log(`  ${story.id}: decomposed into ${subTasks.length} sub-tasks`);
@@ -307,7 +318,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
   // Step 4: AC consolidator
   console.log("Running AC consolidator...");
   const acPath = join(plansDir, "acceptance-criteria.md");
-  await spawnAgentWithRetry({
+  const synthResult = await spawnAgentWithRetry({
     type: "synthesizer",
     model: "opus",
     inputFiles: [stepsDir],
@@ -317,6 +328,7 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
     ],
     memoryContent: feedbackMemory,
   }, config);
+  tracker?.recordAgentCost("PLAN", "synthesizer", synthResult.costUsd, synthResult.durationMs);
 
   console.log("PLAN stage complete.");
 }
@@ -365,6 +377,7 @@ async function decomposeStory(
   stepsDir: string,
   memoryContent: string,
   config: HiveMindConfig,
+  tracker?: CostTracker,
 ): Promise<SubTask[]> {
   // Decompose all high-complexity stories regardless of file count.
   // Dogfood finding: planner always creates 1-file stories, so the old 3-file gate was dead code.
@@ -374,7 +387,7 @@ async function decomposeStory(
   const outputPath = join(stepsDir, `${story.id}-subtasks.json`);
 
   try {
-    await spawnAgentWithRetry({
+    const decomposerResult = await spawnAgentWithRetry({
       type: "decomposer",
       model: "sonnet",
       inputFiles: [stepFilePath],
@@ -382,6 +395,7 @@ async function decomposeStory(
       rules: getAgentRules("decomposer"),
       memoryContent,
     }, config);
+    tracker?.recordAgentCost("PLAN", "decomposer", decomposerResult.costUsd, decomposerResult.durationMs);
 
     const content = readFileSafe(outputPath);
     if (!content) {

--- a/src/stages/spec-stage.ts
+++ b/src/stages/spec-stage.ts
@@ -10,6 +10,7 @@ import { loadConstitution } from "../config/loader.js";
 import type { PipelineDirs } from "../types/pipeline-dirs.js";
 import { checkTruncation } from "../utils/truncation-monitor.js";
 import { estimateTokens } from "../utils/token-count.js";
+import type { CostTracker } from "../utils/cost-tracker.js";
 
 const SPEC_STEPS = [
   "research-report.md",
@@ -64,6 +65,7 @@ export async function runSpecStage(
   config: HiveMindConfig,
   feedback?: string,
   greenfield?: boolean,
+  tracker?: CostTracker,
 ): Promise<void> {
   const specDir = join(dirs.workingDir, "spec");
   ensureDir(specDir);
@@ -95,7 +97,7 @@ export async function runSpecStage(
     rules: getAgentRules("researcher"),
     instructionBlocks: researcherBlocks,
     memoryContent,
-  }, config, constitutionContent);
+  }, config, constitutionContent, tracker);
 
   const researchReport = join(specDir, "research-report.md");
 
@@ -126,7 +128,7 @@ export async function runSpecStage(
     memoryContent: feedback
       ? `${memoryContent}\n\n## HUMAN FEEDBACK (from rejection)\n${feedback}`
       : memoryContent,
-  }, config, constitutionContent);
+  }, config, constitutionContent, tracker);
 
   const specDraft = join(specDir, "SPEC-draft.md");
 
@@ -139,7 +141,7 @@ export async function runSpecStage(
     outputFile: join(specDir, "critique-1.md"),
     rules: getAgentRules("critic"),
     memoryContent,
-  }, config, constitutionContent);
+  }, config, constitutionContent, tracker);
 
   const critique1 = join(specDir, "critique-1.md");
 
@@ -153,7 +155,7 @@ export async function runSpecStage(
     rules: getAgentRules("spec-corrector"),
     instructionBlocks: [SELF_REVIEW_BLOCK],
     memoryContent,
-  }, config, constitutionContent);
+  }, config, constitutionContent, tracker);
 
   const specV02 = join(specDir, "SPEC-v0.2.md");
 
@@ -166,7 +168,7 @@ export async function runSpecStage(
     outputFile: join(specDir, "critique-2.md"),
     rules: getAgentRules("critic"),
     memoryContent,
-  }, config, constitutionContent);
+  }, config, constitutionContent, tracker);
 
   const critique2 = join(specDir, "critique-2.md");
 
@@ -180,16 +182,17 @@ export async function runSpecStage(
     rules: getAgentRules("spec-corrector"),
     instructionBlocks: [SELF_REVIEW_BLOCK],
     memoryContent,
-  }, config, constitutionContent);
+  }, config, constitutionContent, tracker);
 
   console.log("SPEC stage complete. 6 artifacts produced.");
 }
 
 const MODEL_MAX_TOKENS = 200_000; // Conservative estimate for structured output
 
-async function spawnStep(agentConfig: AgentConfig, hiveMindConfig: HiveMindConfig, constitutionContent?: string): Promise<void> {
+async function spawnStep(agentConfig: AgentConfig, hiveMindConfig: HiveMindConfig, constitutionContent?: string, tracker?: CostTracker): Promise<void> {
   const config = constitutionContent ? { ...agentConfig, constitutionContent } : agentConfig;
   const result = await spawnAgentWithRetry(config, hiveMindConfig);
+  tracker?.recordAgentCost("SPEC", agentConfig.type, result.costUsd, result.durationMs);
   if (!result.success) {
     // Empty critique is acceptable — log warning but proceed
     if (agentConfig.type === "critic") {

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -57,4 +57,5 @@ export interface AgentResult {
   modelUsed?: string;
   sessionId?: string;
   durationMs?: number;
+  killedByOutputDetection?: boolean;
 }

--- a/src/utils/cost-tracker.ts
+++ b/src/utils/cost-tracker.ts
@@ -8,6 +8,15 @@ export interface AgentCostEntry {
   timestamp: string;
 }
 
+export interface TimingSummary {
+  totalDurationMs: number;
+  agentCount: number;
+  fastest: { agentType: string; storyId: string; durationMs: number } | null;
+  median: { agentType: string; storyId: string; durationMs: number } | null;
+  slowest: { agentType: string; storyId: string; durationMs: number } | null;
+  perAgent: Array<{ storyId: string; agentType: string; durationMs: number; costUsd: number }>;
+}
+
 export interface CostSummary {
   totalCostUsd: number;
   totalDurationMs: number;
@@ -69,6 +78,28 @@ export class CostTracker {
         `Budget exceeded: $${this.getPipelineTotal().toFixed(4)} spent, budget is $${this.budgetUsd!.toFixed(2)}`,
       );
     }
+  }
+
+  getTimingSummary(): TimingSummary {
+    const sorted = [...this.entries]
+      .filter(e => e.durationMs > 0)
+      .sort((a, b) => a.durationMs - b.durationMs);
+
+    const pick = (e: AgentCostEntry) => ({
+      agentType: e.agentType, storyId: e.storyId, durationMs: e.durationMs,
+    });
+
+    return {
+      totalDurationMs: sorted.reduce((s, e) => s + e.durationMs, 0),
+      agentCount: sorted.length,
+      fastest: sorted.length > 0 ? pick(sorted[0]) : null,
+      median: sorted.length > 0 ? pick(sorted[Math.floor(sorted.length / 2)]) : null,
+      slowest: sorted.length > 0 ? pick(sorted[sorted.length - 1]) : null,
+      perAgent: sorted.map(e => ({
+        storyId: e.storyId, agentType: e.agentType,
+        durationMs: e.durationMs, costUsd: e.costUsd,
+      })),
+    };
   }
 
   getSummary(): CostSummary {

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -131,6 +131,7 @@ export function spawnClaude(options: ClaudeSpawnOptions): Promise<ClaudeSpawnRes
       pollTimer = setInterval(() => {
         if (existsSync(options.outputFile!)) {
           killedByOutputDetection = true;
+          console.log(`[spawnClaude] Output file detected, terminating process early: ${options.outputFile}`);
           child.kill("SIGTERM");
         }
       }, interval);


### PR DESCRIPTION
## Summary
- Add per-agent timing logs (`[agent:<type>] completed in Xs`), `killedByOutputDetection` flag passthrough, and `getTimingSummary()` on `CostTracker` (fastest/median/slowest)
- Print timing summary to console and write `timing-report.md` with markdown table at pipeline end
- Add 8 new tests across 3 files covering all timing acceptance criteria (AC#1-8)

## Test plan
- [x] `getTimingSummary` unit tests — fastest/median/slowest math, zero-filter, all-zero nulls, single entry
- [x] `spawner-timing` unit tests — per-agent timing log, kill flag log, `killedByOutputDetection` in `AgentResult`
- [x] E2E smoke test — pipeline timing summary printed, no timeouts, spec files exist, execution-plan exists, timing-report.md written
- [x] Full test suite: 461 tests passing, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)