### PR TITLE
ci: add AI code review GitHub Action

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,32 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  code-review:
+    if: |
+      github.event.pull_request.draft == false &&
+      !startsWith(github.head_ref, 'release-please--') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
+            Be specific and actionable. Only flag issues with high confidence.
+          claude_args: "--max-turns 5"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/code-review.yml` using `anthropics/claude-code-action@v1`
- Authenticates via Max plan OAuth token (`CLAUDE_CODE_OAUTH_TOKEN` secret)
- Reviews PRs for bugs, security issues, and CLAUDE.md convention violations
- Skips draft PRs, release-please branches, and `skip-review` labeled PRs

## Manual setup required
1. Run `claude setup-token` locally to generate OAuth token
2. Add `CLAUDE_CODE_OAUTH_TOKEN` secret at https://github.com/ziyilam3999/hive-mind/settings/secrets/actions

## Test plan
- [ ] TC1: Action triggers on this PR (check Actions tab)
- [ ] TC2: Review comment appears on this PR
- [ ] TC3: Draft PR → job skipped
- [ ] TC4: PR with `skip-review` label → job skipped
- [ ] TC5: `release-please--*` branch → job skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)