### PR TITLE
feat: add exitCode property to HiveMindError

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,8 +3,11 @@
  * Distinguishes intentional error conditions from unexpected bugs.
  */
 export class HiveMindError extends Error {
-  constructor(message: string) {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
     super(message);
     this.name = "HiveMindError";
+    this.exitCode = exitCode;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `exitCode` property to `HiveMindError` for CLI exit code support
- Also serves as verification for the AI code review action

## Test plan
- [ ] TC1: "AI Code Review" action triggers in the Actions tab
- [ ] TC2: Review comment appears on this PR
- [ ] Type-check passes (`npx tsc --noEmit` — verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)