### PR TITLE
fix(ci): increase code review max-turns to 10

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -30,4 +30,4 @@ jobs:
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
             Be specific and actionable. Only flag issues with high confidence.
-          claude_args: "--max-turns 5"
+          claude_args: "--max-turns 10"


### PR DESCRIPTION
## Summary
- Increases `--max-turns` from 5 to 10 for the AI code review action
- 5 turns was insufficient — Claude hit the cap and errored with `error_max_turns`

## Test plan
- [ ] Merge this, then re-trigger PR #15 to verify full review completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)