### PR TITLE
revert: remove unused exitCode from HiveMindError

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,11 +3,8 @@
  * Distinguishes intentional error conditions from unexpected bugs.
  */
 export class HiveMindError extends Error {
-  readonly exitCode: number;
-
-  constructor(message: string, exitCode = 1) {
+  constructor(message: string) {
     super(message);
     this.name = "HiveMindError";
-    this.exitCode = exitCode;
   }
 }


### PR DESCRIPTION
## Summary
- Reverts the `exitCode` property added in PR #15
- That change was test scaffolding for the code review action and shouldn't have been merged

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)