### PR TITLE
fix(ci): enable full output for code review debugging

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
             Be specific and actionable. Only flag issues with high confidence.


### PR DESCRIPTION
## Summary
- Adds `show_full_output: true` to the code review action
- Needed to diagnose why the action completes successfully but posts no review comments

## Next steps
1. Merge this PR
2. Re-trigger the test violation PR #20 to see full Claude output
3. Once diagnosed, optionally disable `show_full_output` again

🤖 Generated with [Claude Code](https://claude.com/claude-code)