### PR TITLE
fix(ci): pass github_token for PR comment posting

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.


### PR DESCRIPTION
## Summary
- Adds explicit `github_token: ${{ secrets.GITHUB_TOKEN }}` to the code review action
- The OIDC token handles Claude auth, but a separate GitHub token is needed to post PR comments
- Without this, the review runs but comments are never posted (confirmed in PR #24 logs)

## Context
PR #24 logs showed Claude produced an excellent review (found all 4 planted violations) but the action posted nothing because the comment-posting step had no valid GitHub token.

## Test plan
1. Merge this PR
2. Re-trigger PR #24 — comment should appear this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)