### PR TITLE
fix(ci): instruct Claude to post review as PR comment

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -32,4 +32,6 @@ jobs:
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
             Be specific and actionable. Only flag issues with high confidence.
+            After completing your review, post it as a comment on the PR using:
+            gh pr comment ${{ github.event.pull_request.number }} --body "<your review>"
           claude_args: "--max-turns 10"


### PR DESCRIPTION
## Summary
- Updates the prompt to tell Claude to post its review via `gh pr comment`
- In `agent` mode, the action doesn't auto-post result text as a PR comment
- Claude needs explicit instructions to use the `gh` CLI

## Root cause
`claude-code-action` in `agent` mode treats Claude as an autonomous agent with tool access. The final `result` text is logged but not automatically posted. Claude must use available tools (like Bash with `gh pr comment`) to post comments.

## Test plan
1. Merge this PR
2. Re-trigger PR #24 — review comment should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)