### PR TITLE
fix(ci): allow gh CLI commands in code review action

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,6 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
+          additional_permissions: "gh pr comment,gh pr view,gh api"
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
             Be specific and actionable. Only flag issues with high confidence.


### PR DESCRIPTION
## Summary
- Adds `additional_permissions: "gh pr comment,gh pr view,gh api"` to allowlist gh commands
- Claude runs in `default` permission mode which blocks `gh` commands with "This command requires approval"
- This caused the previous run to fail after 10 turns of permission denials

## Test plan
1. Merge this PR
2. Re-trigger PR #24 — Claude should now be able to run `gh pr comment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)