### PR TITLE
fix(ci): use settings input for tool permissions

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,7 +29,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
-          additional_permissions: "gh pr comment,gh pr view,gh api"
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh pr:*)",
+                  "Bash(gh api:*)",
+                  "Bash(git:*)",
+                  "Read",
+                  "Glob",
+                  "Grep"
+                ]
+              }
+            }
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
             Be specific and actionable. Only flag issues with high confidence.


### PR DESCRIPTION
## Summary
- Replaces `additional_permissions` with `settings` input containing explicit `permissions.allow` list
- Allows `gh pr comment/view`, `gh api`, `git`, `Read`, `Glob`, `Grep` tools
- `additional_permissions` didn't actually work — commands were still blocked with "This command requires approval"

## Test plan
1. Merge this PR
2. Re-trigger PR #24 — Claude should be able to run `gh pr comment` now

🤖 Generated with [Claude Code](https://claude.com/claude-code)