### PR TITLE
fix(ci): use --body-file for PR review comment posting

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -45,6 +45,6 @@ jobs:
           prompt: |
             Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
             Be specific and actionable. Only flag issues with high confidence.
-            After completing your review, post it as a comment on the PR using:
-            gh pr comment ${{ github.event.pull_request.number }} --body "<your review>"
+            After completing your review, write it to /tmp/review.md using the Write tool,
+            then post it with: gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review.md
           claude_args: "--max-turns 10"


### PR DESCRIPTION
## Summary
- Changes prompt to write review to `/tmp/review.md` then use `gh pr comment --body-file`
- Claude's markdown review contains `#` headings which trigger a security check that blocks inline multi-line commands with `#`-prefixed lines
- Writing to a file first bypasses this safely

## Test plan
1. Merge this PR
2. Re-trigger PR #24 — review comment should finally appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)