### PR TITLE
feat: evidence-gating, regression tracking, critique log for SPEC pipeline

### DIFF
--- a/src/__tests__/stages/spec-stage.test.ts
+++ b/src/__tests__/stages/spec-stage.test.ts
@@ -379,6 +379,79 @@ describe("spec-stage", () => {
     }
   });
 
+  it("critic rules include EVIDENCE-GATED", async () => {
+    setup();
+    try {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runSpecStage(prdPath, dirs, config);
+      consoleSpy.mockRestore();
+
+      const calls = vi.mocked(spawnAgentWithRetry).mock.calls;
+      const criticCalls = calls.filter((c) => c[0].type === "critic");
+      expect(criticCalls.length).toBe(2);
+
+      // Both critics should have EVIDENCE-GATED rule
+      for (const call of criticCalls) {
+        expect(call[0].rules.some((r: string) => r.includes("EVIDENCE-GATED"))).toBe(true);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("spec-corrector rules include EVIDENCE-GATED", async () => {
+    setup();
+    try {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runSpecStage(prdPath, dirs, config);
+      consoleSpy.mockRestore();
+
+      const calls = vi.mocked(spawnAgentWithRetry).mock.calls;
+      const correctorCalls = calls.filter((c) => c[0].type === "spec-corrector");
+      expect(correctorCalls.length).toBe(2);
+
+      for (const call of correctorCalls) {
+        expect(call[0].rules.some((r: string) => r.includes("EVIDENCE-GATED"))).toBe(true);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("round-2 critic has REGRESSION-CHECK, round-1 does not", async () => {
+    setup();
+    try {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runSpecStage(prdPath, dirs, config);
+      consoleSpy.mockRestore();
+
+      const calls = vi.mocked(spawnAgentWithRetry).mock.calls;
+      const criticCalls = calls.filter((c) => c[0].type === "critic");
+      expect(criticCalls.length).toBe(2);
+
+      // Round 1 should NOT have REGRESSION-CHECK
+      expect(criticCalls[0][0].rules.some((r: string) => r.includes("REGRESSION-CHECK"))).toBe(false);
+
+      // Round 2 should have REGRESSION-CHECK
+      expect(criticCalls[1][0].rules.some((r: string) => r.includes("REGRESSION-CHECK"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("critique-log.md is produced after pipeline completes", async () => {
+    setup();
+    try {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runSpecStage(prdPath, dirs, config);
+      consoleSpy.mockRestore();
+
+      expect(existsSync(join(hmDir, "spec", "critique-log.md"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
   it("getSpecSteps returns correct arrays", () => {
     const fullSteps = getSpecSteps(false);
     expect(fullSteps.length).toBe(9);

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -86,6 +86,7 @@ const AGENT_RULES: Record<string, string[]> = {
     "SKIP-INVALID: If a critique finding is incorrect, explain why it is being skipped rather than silently ignoring it.",
     "NO-OVERCORRECT: Skip MINOR findings that do not materially improve the document. Focus on critical and major issues.",
     "CONSISTENCY-CHECK: After applying fixes, verify all sections still agree with each other. Cross-reference definitions, interfaces, and requirements.",
+    "EVIDENCE-GATED: When fixing a critique finding, cite the specific section you changed and quote the before/after. Format: 'FIXED: <finding #> — changed <section> from \"<before>\" to \"<after>\"'. This creates an audit trail.",
   ],
   "tester-exec": [
     "SHELL-EXEC: Run each AC via Bash. Report exact stdout. Code inspection alone is NOT testing. [Wrong: 'I can see the function exists'] [Right: 'Ran grep -q export... && echo PASS, got PASS']",
@@ -131,7 +132,7 @@ const AGENT_RULES: Record<string, string[]> = {
   ],
   "critic": [
     "INDEPENDENCE: You see ONLY the artifact. No shared context with drafter/researcher. [Wrong: 'Building on the research report...'] [Right: 'Reading only the SPEC draft, I find...']",
-    "CONCRETE: Every finding must cite a specific section, line, or statement.",
+    "EVIDENCE-GATED: Every finding must cite a specific section and quote evidence. Format: 'VERIFIED: <claim> found at <section/line> — \"<quoted text>\"' or 'UNVERIFIED: <claim> — no evidence found'. Do not assert something exists or is missing without citing where you looked.",
     "SEVERITY: Classify each finding as critical, major, or minor.",
     "NO-STYLE: Do not critique writing style, formatting, or word choice unless it causes ambiguity.",
     "ACTIONABLE: Every finding must include a specific recommendation for correction.",

--- a/src/stages/scorecard.ts
+++ b/src/stages/scorecard.ts
@@ -37,6 +37,7 @@ export async function runScorecard(
       maybeAdd(join(dirs.workingDir, "spec", "SPEC-v1.0.md"));
       maybeAdd(join(dirs.workingDir, "spec", "critique-round-1.md"));
       maybeAdd(join(dirs.workingDir, "spec", "critique-round-2.md"));
+      maybeAdd(join(dirs.workingDir, "spec", "critique-log.md"));
       break;
     case "plan":
       maybeAdd(planPath);

--- a/src/stages/spec-stage.ts
+++ b/src/stages/spec-stage.ts
@@ -307,14 +307,17 @@ async function runCritiquePipeline(
 
   const specV02 = join(specDir, "SPEC-v0.2.md");
 
-  // S.7: Critic round 2 — ONLY receives SPEC-v0.2.md (isolation)
+  // S.7: Critic round 2 — ONLY receives SPEC-v0.2.md (isolation) + regression check
   console.log("S.7: Running critic (round 2)...");
   await spawnStep({
     type: "critic",
     model: "sonnet",
     inputFiles: [specV02],
     outputFile: join(specDir, "critique-2.md"),
-    rules: getAgentRules("critic"),
+    rules: [
+      ...getAgentRules("critic"),
+      "REGRESSION-CHECK: You are Round 2. The document you're reviewing was corrected after Round 1. Actively look for NEW problems introduced by the corrections — inconsistencies between fixed sections and untouched sections, broken cross-references, or overcorrections that lost important content. Flag regressions with severity CRITICAL and tag them [REGRESSION].",
+    ],
     memoryContent,
   }, config, constitutionContent, tracker);
 
@@ -331,6 +334,42 @@ async function runCritiquePipeline(
     instructionBlocks: [SELF_REVIEW_BLOCK],
     memoryContent,
   }, config, constitutionContent, tracker);
+
+  // Compile critique log from both rounds (non-agent, local file-write)
+  compileCritiqueLog(specDir);
+}
+
+function compileCritiqueLog(specDir: string): void {
+  const critique1 = readFileSafe(join(specDir, "critique-1.md")) ?? "";
+  const critique2 = readFileSafe(join(specDir, "critique-2.md")) ?? "";
+
+  const countSeverity = (text: string, pattern: string): number =>
+    (text.match(new RegExp(pattern, "gi")) || []).length;
+
+  const log = `# Critique Log
+
+## Round 1 Summary
+- Critical: ${countSeverity(critique1, "critical")}
+- Major: ${countSeverity(critique1, "major")}
+- Minor: ${countSeverity(critique1, "minor")}
+
+## Round 2 Summary
+- Critical: ${countSeverity(critique2, "critical")}
+- Major: ${countSeverity(critique2, "major")}
+- Minor: ${countSeverity(critique2, "minor")}
+- Regressions: ${countSeverity(critique2, "\\[REGRESSION\\]")}
+
+## Round 1 Findings
+${critique1 || "(empty)"}
+
+## Round 2 Findings
+${critique2 || "(empty)"}
+
+## Generated: ${new Date().toISOString()}
+`;
+
+  writeFileAtomic(join(specDir, "critique-log.md"), log);
+  console.log("Compiled critique-log.md");
 }
 
 const MODEL_MAX_TOKENS = 200_000;


### PR DESCRIPTION
## Summary
- **Evidence-gated verification**: Critic rules now require `VERIFIED`/`UNVERIFIED` citation format with quoted evidence. Spec-corrector rules require `FIXED` format with before/after quotes. Merged with existing CONCRETE rule to stay within 5-rule limit.
- **Regression tracking**: Round-2 critic gets an inline `REGRESSION-CHECK` rule to actively look for issues introduced by round-1 corrections, tagged `[REGRESSION]` with CRITICAL severity.
- **Critique log compilation**: After the critique pipeline, a local `critique-log.md` is compiled with severity counts from both rounds. Wired into scorecard inputs.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 519 tests pass (68 test files)
- [x] 4 new tests: evidence-gated rules on critic/corrector, regression-check on round-2 only, critique-log.md produced
- [x] Max-5 rule limit respected (critic consolidated to 5 rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)