### PR TITLE
feat: pipeline hardening for e2e execution

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -168,6 +168,7 @@ export function loadConfig(projectRoot: string): HiveMindConfig {
     toolingDetectTimeout: (obj.toolingDetectTimeout as number | undefined) ?? defaults.toolingDetectTimeout,
     maxRetries: (obj.maxRetries as number | undefined) ?? defaults.maxRetries,
     maxAttempts: (obj.maxAttempts as number | undefined) ?? defaults.maxAttempts,
+    maxBuildAttempts: (obj.maxBuildAttempts as number | undefined) ?? defaults.maxBuildAttempts,
     maxConcurrency: (obj.maxConcurrency as number | undefined) ?? defaults.maxConcurrency,
     retryBaseDelayMs: (obj.retryBaseDelayMs as number | undefined) ?? defaults.retryBaseDelayMs,
     retryMaxDelayMs: (obj.retryMaxDelayMs as number | undefined) ?? defaults.retryMaxDelayMs,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,6 +6,7 @@ export interface HiveMindConfig {
   toolingDetectTimeout: number;
   maxRetries: number;
   maxAttempts: number;
+  maxBuildAttempts: number;
   maxConcurrency: number;
   retryBaseDelayMs: number;
   retryMaxDelayMs: number;
@@ -72,6 +73,7 @@ export const DEFAULT_CONFIG: HiveMindConfig = {
   toolingDetectTimeout: 30_000,
   maxRetries: 1,
   maxAttempts: 3,
+  maxBuildAttempts: 2,
   maxConcurrency: 3,
   retryBaseDelayMs: 1000,
   retryMaxDelayMs: 16_000,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,5 @@
 import type { Checkpoint } from "./types/checkpoint.js";
-import type { ExecutionPlan } from "./types/execution-plan.js";
+import type { ExecutionPlan, SourceFileEntry } from "./types/execution-plan.js";
 import { getSourceFilePaths } from "./types/execution-plan.js";
 import type { HiveMindConfig } from "./config/schema.js";
 import type { PipelineDirs } from "./types/pipeline-dirs.js";
@@ -26,7 +26,9 @@ import { runWithConcurrency } from "./utils/concurrency.js";
 import { appendLogEntry, createLogEntry } from "./state/manager-log.js";
 import { isoTimestamp } from "./utils/timestamp.js";
 import { join, resolve, dirname } from "node:path";
-import { rmSync, readdirSync, writeFileSync, copyFileSync } from "node:fs";
+import { rmSync, readdirSync, writeFileSync, copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
 import { HiveMindError } from "./utils/errors.js";
 import { notifyCheckpoint } from "./utils/notify.js";
 import { CostTracker, estimatePipelineCost } from "./utils/cost-tracker.js";
@@ -37,7 +39,7 @@ import { runVerify } from "./stages/execute-verify.js";
 import { runCommit } from "./stages/execute-commit.js";
 import { runLearn } from "./stages/execute-learn.js";
 import { runComplianceCheck } from "./stages/execute-compliance.js";
-import { parseRequiredTooling, detectAllTools } from "./tooling/detect.js";
+import { parseRequiredTooling, detectAllTools, scanStepFileForTools, detectToolBySpawn } from "./tooling/detect.js";
 import { runToolingSetup } from "./tooling/setup.js";
 import { runReportStage as reportStage } from "./stages/report-stage.js";
 import { runBaselineCheck } from "./stages/baseline-check.js";
@@ -580,10 +582,94 @@ async function executeWholeStory(
     } catch { /* ignore corrupt checkpoint */ }
   }
 
-  // BUILD sub-pipeline (US-13)
+  // BUILD sub-pipeline (US-13) — with retry loop
   if (!completedSubStages.has("BUILD")) {
-    console.log(`[${story.id}] BUILD: Starting...`);
-    await runBuild(story, dirs, config, costTracker, roleReportsDir, undefined, moduleCwd);
+    const maxBuildAttempts = config.maxBuildAttempts ?? 2;
+    let buildPassed = false;
+
+    for (let attempt = 1; attempt <= maxBuildAttempts; attempt++) {
+      try {
+        console.log(`[${story.id}] BUILD: Starting (attempt ${attempt}/${maxBuildAttempts})...`);
+        await runBuild(story, dirs, config, costTracker, roleReportsDir, undefined, moduleCwd);
+        buildPassed = true;
+        break;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const isRetryable =
+          msg.startsWith("BUILD file existence check failed") ||
+          msg.startsWith("BUILD type-check gate failed");
+
+        if (!isRetryable || attempt === maxBuildAttempts) {
+          if (!isRetryable) {
+            // Non-retryable error — propagate immediately
+            throw err;
+          }
+          // Exhausted retries
+          appendLogEntry(logPath, createLogEntry("BUILD_RETRY_EXHAUSTED", {
+            storyId: story.id,
+            attempt,
+            error: msg,
+          }));
+          return {
+            storyId: story.id,
+            passed: false,
+            attempts: attempt,
+            errorMessage: `BUILD failed after ${attempt} attempts: ${msg}`,
+          };
+        }
+
+        // Retryable error — clean up and retry
+        console.warn(`[${story.id}] BUILD attempt ${attempt} failed: ${msg}`);
+        appendLogEntry(logPath, createLogEntry("BUILD_RETRY", {
+          storyId: story.id,
+          attempt,
+          error: msg,
+        }));
+
+        // Delete the mid-story checkpoint so BUILD re-runs from scratch
+        const cpPath = join(dirs.workingDir, getReportPath(story.id, "checkpoint.json"));
+        if (existsSync(cpPath)) {
+          unlinkSync(cpPath);
+        }
+
+        // Restore MODIFIED files via git checkout
+        const cwd = moduleCwd ?? dirs.workingDir;
+        const modifiedFiles = story.sourceFiles.filter(
+          (f): f is SourceFileEntry => typeof f !== "string" && f.changeType === "MODIFIED",
+        );
+        for (const f of modifiedFiles) {
+          try {
+            execSync(`git checkout -- "${f.path}"`, { cwd, stdio: "ignore" });
+          } catch {
+            console.warn(`[${story.id}] BUILD_RETRY: Could not restore ${f.path}`);
+          }
+        }
+
+        // Move ADDED files to .retry-trash/
+        const addedFiles = story.sourceFiles.filter(
+          (f): f is SourceFileEntry => typeof f !== "string" && f.changeType === "ADDED",
+        );
+        if (addedFiles.length > 0) {
+          const trashDir = join(cwd, ".retry-trash", `${story.id}-attempt${attempt}`);
+          mkdirSync(trashDir, { recursive: true });
+          for (const f of addedFiles) {
+            const fullPath = join(cwd, f.path);
+            if (existsSync(fullPath)) {
+              renameSync(fullPath, join(trashDir, basename(f.path)));
+            }
+          }
+        }
+      }
+    }
+
+    if (!buildPassed) {
+      return {
+        storyId: story.id,
+        passed: false,
+        attempts: maxBuildAttempts,
+        errorMessage: "BUILD failed after max attempts",
+      };
+    }
   } else {
     console.log(`[${story.id}] BUILD: Skipped (checkpoint)`);
   }
@@ -727,6 +813,41 @@ async function executeStoryWithSubTasks(
   };
 }
 
+/**
+ * Pre-flight tool check: scan all step files for CLI tool dependencies
+ * and verify they are available on PATH. Returns array of missing tool names.
+ */
+async function runPreFlightChecks(
+  plan: ExecutionPlan,
+  dirs: PipelineDirs,
+): Promise<string[]> {
+  const allTools = new Set<string>();
+
+  for (const story of plan.stories) {
+    if (story.status === "passed" || story.status === "failed" || story.status === "skipped") continue;
+
+    const stepPath = join(dirs.workingDir, "plans", story.stepFile);
+    const content = readFileSafe(stepPath);
+    if (!content) continue;
+
+    for (const tool of scanStepFileForTools(content)) {
+      allTools.add(tool);
+    }
+  }
+
+  if (allTools.size === 0) return [];
+
+  const missing: string[] = [];
+  for (const tool of allTools) {
+    const status = await detectToolBySpawn(tool);
+    if (status === "missing") {
+      missing.push(tool);
+    }
+  }
+
+  return missing;
+}
+
 export async function runExecuteStage(
   dirs: PipelineDirs,
   config: HiveMindConfig,
@@ -789,6 +910,21 @@ export async function runExecuteStage(
       // Non-interactive (CI/tests): auto-approve with log
       console.log("Non-interactive mode — auto-approved.");
     }
+  }
+
+  // Pre-flight tool check: scan step files for CLI tool dependencies
+  const preflightMissing = await runPreFlightChecks(plan, dirs);
+  if (preflightMissing.length > 0) {
+    const msg = `Missing tools: ${preflightMissing.join(", ")}. Install them and re-run.`;
+    console.error(`PRE-FLIGHT FAILED: ${msg}`);
+    writeCheckpoint(dirs.workingDir, {
+      awaiting: "approve-preflight",
+      message: getCheckpointMessage("approve-preflight"),
+      timestamp: isoTimestamp(),
+      feedback: null,
+    });
+    notifyCheckpoint(false);
+    return;
   }
 
   // Wave executor: process stories in waves of non-overlapping, dependency-ready stories

--- a/src/stages/execute-build.ts
+++ b/src/stages/execute-build.ts
@@ -1,5 +1,5 @@
 import type { Story } from "../types/execution-plan.js";
-import { getSourceFilePaths } from "../types/execution-plan.js";
+import { getSourceFilePaths, type SourceFileEntry } from "../types/execution-plan.js";
 import type { StoryCheckpoint } from "../types/checkpoint.js";
 import { writeFileAtomic } from "../utils/file-io.js";
 import { isoTimestamp } from "../utils/timestamp.js";
@@ -63,6 +63,15 @@ export async function runBuild(
     cwd: moduleCwd ?? process.cwd(),
   }, config);
   costTracker?.recordAgentCost(story.id, "implementer", implResult.costUsd, implResult.durationMs);
+
+  // Early file existence check — catch phantom files before wasting refactorer time
+  const earlyAddedFiles = (subTaskScope ? subTaskScope.sourceFiles : story.sourceFiles)
+    .filter((f): f is SourceFileEntry => typeof f !== "string" && f.changeType === "ADDED")
+    .map(f => join(moduleCwd ?? process.cwd(), f.path));
+  const missingAfterImpl = earlyAddedFiles.filter(f => !existsSync(f));
+  if (missingAfterImpl.length > 0) {
+    throw new Error(`BUILD file existence check failed (pre-refactor): missing: ${missingAfterImpl.join(", ")}`);
+  }
 
   // E.2: Refactorer — receives source code + impl-report + memory
   const refactorReportPath = join(dirs.workingDir, getReportPath(story.id, "refactor-report.md"));

--- a/src/stages/plan-stage.ts
+++ b/src/stages/plan-stage.ts
@@ -237,7 +237,28 @@ DELTA MARKERS: Every sourceFiles entry MUST be an object with "path" (file path)
 
   // Fallback heuristic: warn about registry gaps the validator may have missed
   const workspaceRoot = join(dirs.workingDir, "..");
-  warnRegistryGaps(planData.stories, workspaceRoot, parsedModules.length > 0);
+  const registryGaps = warnRegistryGaps(planData.stories, workspaceRoot, parsedModules.length > 0);
+
+  // Auto-fix registry gaps: add missing registry files to suggested owner's sourceFiles
+  if (registryGaps.length > 0) {
+    for (const gap of registryGaps) {
+      const ownerStory = stories.find(s => s.id === gap.suggestedOwner);
+      if (!ownerStory) continue;
+
+      const alreadyListed = ownerStory.sourceFiles.some(sf => {
+        const path = typeof sf === "string" ? sf : sf.path;
+        return path === gap.registryFile;
+      });
+      if (alreadyListed) continue;
+
+      const changeType = fileExists(join(workspaceRoot, gap.registryFile)) ? "MODIFIED" : "ADDED";
+      ownerStory.sourceFiles.push({ path: gap.registryFile, changeType });
+      console.log(`[PLAN] Auto-fixed registry gap: added ${gap.registryFile} to ${gap.suggestedOwner} sourceFiles`);
+    }
+    // Re-save execution plan with patched sourceFiles
+    planData.stories = stories;
+    writeFileAtomic(planJsonPath, JSON.stringify(planData, null, 2) + "\n");
+  }
 
   // Write story skeletons for ac/ec generators
   for (const story of stories) {
@@ -526,8 +547,14 @@ export function extractCorrectedPlan(report: string): { stories: Story[] } | nul
   return null;
 }
 
-export function warnRegistryGaps(stories: Story[], workspaceRoot: string, hasModules: boolean): void {
-  if (hasModules) return;
+export interface RegistryGap {
+  registryFile: string;
+  addingStories: string[];
+  suggestedOwner: string;
+}
+
+export function warnRegistryGaps(stories: Story[], workspaceRoot: string, hasModules: boolean): RegistryGap[] {
+  if (hasModules) return [];
 
   const addedDirs = new Map<string, string[]>();
   const modifiedFiles = new Set<string>();
@@ -547,6 +574,7 @@ export function warnRegistryGaps(stories: Story[], workspaceRoot: string, hasMod
     }
   }
 
+  const gaps: RegistryGap[] = [];
   const REGISTRY_NAMES = ["index.ts", "index.js", "registry.ts", "mod.ts"];
   for (const [dir, storyIds] of addedDirs) {
     for (const name of REGISTRY_NAMES) {
@@ -556,7 +584,14 @@ export function warnRegistryGaps(stories: Story[], workspaceRoot: string, hasMod
           `[PLAN] Registry gap: stories ${storyIds.join(", ")} add files to ${dir}/ ` +
           `but no story modifies ${registryPath}`,
         );
+        gaps.push({
+          registryFile: registryPath,
+          addingStories: storyIds,
+          suggestedOwner: storyIds[storyIds.length - 1],
+        });
       }
     }
   }
+
+  return gaps;
 }

--- a/src/state/checkpoint.ts
+++ b/src/state/checkpoint.ts
@@ -59,6 +59,8 @@ export function getCheckpointMessage(type: CheckpointType): string {
       return "Review integration verification results. Run: hive-mind approve OR hive-mind reject --feedback '...'";
     case "approve-diagnosis":
       return "Review diagnosis report. Run: hive-mind approve (continue with fix) OR hive-mind reject --feedback '...'";
+    case "approve-preflight":
+      return "Missing tools detected. Install the listed tools, then run: hive-mind approve";
     case "verify":
       return "Review consolidated report and retrospective. Run: hive-mind approve OR hive-mind reject --feedback '...'";
     case "ship":

--- a/src/tooling/detect.ts
+++ b/src/tooling/detect.ts
@@ -88,6 +88,35 @@ export interface ToolingRequirement {
   detectCommand: string;
 }
 
+/**
+ * Scan step-file content for CLI tool invocations and return unique tool names.
+ * Only matches actual CLI usage patterns (e.g. `docker build`), not bare mentions.
+ */
+export function scanStepFileForTools(content: string): string[] {
+  const found = new Set<string>();
+
+  const patterns: { regex: RegExp; tool: string }[] = [
+    { regex: /\b(docker)\s+(build|run|compose|push|pull|exec|login|tag|network|volume)\b/gi, tool: "docker" },
+    { regex: /\b(redis-cli|redis-server)\b/gi, tool: "" }, // tool name extracted from match
+    { regex: /\b(psql|createdb|pg_dump)\b/gi, tool: "" },
+    { regex: /\b(docker-compose)\s/gi, tool: "docker-compose" },
+  ];
+
+  for (const { regex, tool } of patterns) {
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      if (tool) {
+        found.add(tool);
+      } else {
+        // Use the captured group (the tool name itself)
+        found.add(match[1].toLowerCase());
+      }
+    }
+  }
+
+  return [...found];
+}
+
 export function parseRequiredTooling(specContent: string): ToolingRequirement[] {
   const requirements: ToolingRequirement[] = [];
 

--- a/src/types/checkpoint.ts
+++ b/src/types/checkpoint.ts
@@ -1,4 +1,4 @@
-export type CheckpointType = "approve-normalize" | "approve-spec" | "approve-plan" | "approve-integration" | "approve-diagnosis" | "verify" | "ship";
+export type CheckpointType = "approve-normalize" | "approve-spec" | "approve-plan" | "approve-integration" | "approve-diagnosis" | "approve-preflight" | "verify" | "ship";
 
 export interface Checkpoint {
   awaiting: CheckpointType;

--- a/src/types/manager-log.ts
+++ b/src/types/manager-log.ts
@@ -20,6 +20,8 @@ export type LogAction =
   | "VERIFY_COMPLETE"
   | "BUG_FIX_COMPLETE"
   | "BUG_FIX_EXHAUSTED"
+  | "BUILD_RETRY"
+  | "BUILD_RETRY_EXHAUSTED"
   | "PIPELINE_START";
 
 export interface ManagerLogEntry {


### PR DESCRIPTION
## Summary
- **Fix 1**: BUILD retry loop with MODIFIED file restore + ADDED file trash (configurable `maxBuildAttempts`, default 2)
- **Fix 2**: Pre-flight tool dependency check with `approve-preflight` checkpoint (pause + guide pattern)
- **Fix 3**: Early file gate between implementer and refactorer (catches phantom files pre-refactor)
- **Fix 4**: Registry gap auto-inject (warnRegistryGaps returns gaps, auto-fixes sourceFiles)

## Context
After 3 pipeline runs on monday-bot (31/32 passed), diagnosis found all remaining issues were pipeline-level. These 4 fixes address the root causes:
- Phantom files (12.5% of stories) → Fix 1 + Fix 3
- Missing Docker → Fix 2
- Command registration gaps → Fix 4

## Test plan
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm test` passes (519 tests, 68 files, 0 failures)
- [ ] Re-run monday-bot pipeline end-to-end (validation planned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)