### PR TITLE
feat: enhance /prd skill with gstack product diagnostic

### DIFF
--- a/tests/double-critique/effectiveness-2026-03-22.md
+++ b/tests/double-critique/effectiveness-2026-03-22.md
@@ -1,156 +1,194 @@
 # Double-Critique Pipeline -- Effectiveness Report
 
-**Date:** 2026-03-22
-**Run number:** 8 (cumulative)
-**Runs covered:** 8 (Run 1: 2026-03-08 fixture, Run 2: 2026-03-08 e2e-bugfix, Run 3: 2026-03-14 phase-6-plan, Run 4: 2026-03-15 post-mvp-plan, Run 5: 2026-03-17 normalize-stage-plan, Run 6: 2026-03-21 pipeline-failure-fix-plan, Run 7: 2026-03-21 CI/CD reference guide, Run 8: 2026-03-22 pipeline-bug-fix-plan)
+**Date:** 2026-03-22 (Run 2 of the day)
+**Run number:** 9 (cumulative)
+**Runs covered:** 9 (Run 1: 2026-03-08 fixture, Run 2: 2026-03-08 e2e-bugfix, Run 3: 2026-03-14 phase-6-plan, Run 4: 2026-03-15 post-mvp-plan, Run 5: 2026-03-17 normalize-stage-plan, Run 6: 2026-03-21 pipeline-failure-fix-plan, Run 7: 2026-03-21 CI/CD reference guide, Run 8: 2026-03-22 pipeline-bug-fix-plan, Run 9: 2026-03-22 PRD workflow recommendation)
 **Author:** Effectiveness analysis agent
 
 ---
 
 ## This Run
 
-Run 8 critiqued an implementation plan for 3 pipeline bugs and produced 20 findings across two critique rounds, all applied, with two compilation blockers caught and a late-stage architectural pivot that improved the final design.
+This section captures the vital signs of the current run -- how many issues were found, how many were fixed, and whether the pipeline introduced any new problems of its own.
 
-- **Document critiqued:** Implementation plan for fixing 3 pipeline bugs in hive-mind (scope rules, max-5 enforcement, uncommitted stories), processed via `tmp/dc-{1..9}-*.md` stages
-- **Total findings: 20** (critic-originated, actionable)
-  - CRITICAL: 2 (1 from Critic-1: overlap guard category mismatch; 1 from Critic-2: `config.projectRoot` does not exist in `HiveMindConfig`)
-  - MAJOR: 9 (5 from Critic-1: false-positive registry warnings, no salvage safety criteria, incomplete path traversal guard, rule merge loses specificity, zero test coverage for riskiest code; 4 from Critic-2: multi-module path resolution, salvage ordering atomicity gap, sub-task impl reports missed, wrong import paths + duplicates)
-  - MINOR: 9 (4 from Critic-1: incorrect `console.warn` rationale, issue numbering inconsistency, shell injection via `git add`, anti-pattern references unexplained; 5 from Critic-2: separator row filter too aggressive, missing `Story` type import, `--pathspec-from-file` requires git 2.26+, no multi-module test, `computeModifiedFiles`/`runCommit` changes prose-only)
-- **Application rate: 100%** (20/20 actionable findings applied; zero rejections)
-- **Pre-critic findings (Researcher):** 7 verified claims (key corrections: max-5 applies to ALL agent types not just refactorer, `ensureDirSync` does not exist in codebase), YAGNI flag on `envRequires`, missing caller audit, 4 knowledge-base cross-references (F2, F49, F32, C-SCALE-2). All resolved by the Drafter before critics saw the document.
-- **Corrector-1 regressions: 1** (`config.projectRoot` type error perpetuated with false self-review verification)
-- **Corrector-2 regressions: 0** (also produced architectural pivot to `plan-validator` agent)
+- **Document critiqued:** Recommendation report on whether hive-mind should add a PRD creation workflow (`tmp/dc-{1..9}-*.md` stages)
+- **Total findings: 18** (critic-originated)
+  - CRITICAL: 3 (1 from Critic-1: VALIDATE self-undermines its value proposition; 2 from Critic-2: NORMALIZE schema mismatch 7-vs-10 sections, fabricated KB citations claim [FALSE POSITIVE])
+  - MAJOR: 7 (3 from Critic-1: no evidence guided interview improves quality, session interruption handling inadequate, Gap 2 never resolved; 4 from Critic-2: constitution path wrong directory-vs-file, session persistence doesn't fit slash command model, VALIDATE "10 sections" conflicts with NORMALIZE 7-section output, evidence-gating trust gap)
+  - MINOR: 8 (5 from Critic-1: cost argument confused, "no HOW sections" under-specified, user story generation stated as trivial, straw-man "What NOT to build" entries, no user disagreement handling; 3 from Critic-2: line count 20 not 19, HOW-check examples too narrow, cost note internal contradictions)
+- **Application rate: 88%** (15/17 actionable findings applied; 1 Critic-2 finding was a false positive and excluded from actionable count; 2 findings rejected with documented rationale -- Critic-1 F8 straw-man entries, Critic-2 F9 trust gap dismissed because premise was wrong)
+- **Drafter regressions: 2** (introduced wrong constitution path `constitution/` instead of `constitution.md`, introduced unresolved VALIDATE contradiction by including both the mechanism and the evidence against it without reconciling)
+- **Corrector-1 regressions: 1** (introduced naive Gap 2 resolution proposing "~20 lines of section-presence checking" that ignores the NORMALIZE 7-vs-10 schema mismatch)
+- **Evidence-gating compliance: 82%** (18 verification claims with evidence / 22 total verification claims; Corrector-1 inherited 4 KB citations from the Drafter without re-verifying them)
+- **False verification claims: 0** (all 18 evidence-backed claims were independently confirmed accurate; the 4 inherited claims also turned out to be correct, though the protocol gap is real)
 - **Pipeline variant:** 7-stage (Reader, Researcher, Drafter, Critic-1, Corrector-1, Critic-2, Corrector-2). No Justifier stage.
 
 ### Stages that carried weight vs. stages that added nothing
 
+The columns below: **Contribution** rates the stage's impact on this run (HIGH/MEDIUM/LOW). **Key output** summarizes the most important deliverables.
+
 | Stage | Contribution | Key output |
 |-------|-------------|-----------|
-| Researcher (2) | **HIGH -- co-MVP** | Caught both compilation blockers (`ensureDirSync` nonexistent, max-5 applies to all 37 agent types), corrected the key factual error, killed ENV-TAGGING and `envRequires` as YAGNI, surfaced 4 knowledge-base patterns that shaped 3 design decisions. Zero false positives. The extractor calls it "the single most valuable stage this run." |
-| Critic-1 (4) | **HIGH -- co-MVP** | 10 findings (1C/5M/4Mi). Found the CRITICAL overlap guard category mismatch -- the deepest logical flaw in the plan. Also surfaced the missing test coverage gap (leading to 6 new test cases) and the shell injection vulnerability. |
-| Critic-2 (6) | **HIGH** | 10 findings (1C/4M/5Mi), zero overlap with Critic-1. Found the CRITICAL `config.projectRoot` type error that both Drafter and Corrector-1 falsely claimed to have verified. Also caught multi-module path resolution, sub-task impl report gap, and wrong import paths. |
-| Corrector-2 (7) | **HIGH** | Applied 10/10 findings (100%). Made the architectural pivot to `plan-validator` agent -- the single largest quality improvement. Added `hasModules` guard, sub-task iteration, fixed imports. Expanded test cases from 21 to 26. Zero regressions. |
-| Drafter (3) | **MEDIUM-HIGH** | Rewrote plan incorporating all Researcher findings, self-caught 4 issues (empty commit check, `runShell` syntax, missing try/catch, weak path guard). But introduced 2 defects: `config.projectRoot` type error (with false self-review) and logically flawed overlap guard. |
-| Corrector-1 (5) | **MEDIUM** | Applied 10/10 Critic-1 findings (shell injection fix, salvage criteria, path traversal hardening, 5 new test cases). But perpetuated the `config.projectRoot` error with its own false self-review verification. 1 regression. |
-| Reader (1) | **LOW** | Catalogued 9 claims, 13 implementation items, 11 test cases, 9 files touched. Did not evaluate whether any claim was wrong. Zero original findings. |
+| Researcher (2) | **HIGH -- MVP of the run** | 10+ findings: P30 gap, F2/F9 warnings, path bug (`document-guidelines.md` wrong path), cost data debunked ($10-40 vs ~$0.10), 6 omitted PRD examples, 6 missing failure mode specs, compliance hierarchy concern. Zero false positives. The extractor calls it "the most valuable single stage." |
+| Critic-2 (6) | **HIGH** | 9 findings (2C/4M/3Mi). Found the NORMALIZE schema mismatch (the most architecturally important discovery in the entire pipeline) and the constitution path error. Also surfaced the session persistence model mismatch. Offset by a dangerous false positive (Finding 1: falsely claimed KB citations were fabricated). |
+| Corrector-2 (7) | **HIGH** | Applied 7/9, correctly rejected 2. The single best judgment call: rejecting Finding 1 (fabricated citations) after independent verification. Produced the three-option Gap 2 resolution table. Zero regressions. |
+| Critic-1 (4) | **HIGH** | 9 findings (1C/3M/5Mi). Found the VALIDATE value-proposition contradiction -- the most important structural problem in the document. Also caught the missing evidence for the central thesis and the unresolved Gap 2. |
+| Drafter (3) | **MEDIUM-HIGH** | Integrated 10+ Researcher findings into a coherent rewrite. Added evidence-gated self-review (13 claims with file paths and line numbers). But introduced 2 regressions (wrong constitution path, unresolved VALIDATE contradiction). |
+| Corrector-1 (5) | **MEDIUM** | Applied 8/9 Critic-1 findings (session persistence, Gap 2 closure, cost reframing, HOW-check examples). But introduced 1 regression (naive Gap 2 resolution ignoring schema mismatch) and inherited the Drafter's constitution path error without checking. |
+| Reader (1) | **LOW** | No evaluative contribution. Zero original findings. The extractor does not mention any Reader output shaping downstream work. 9th consecutive run with zero evaluative value. |
 
 ---
 
 ## Cross-Run Trends
 
-Finding volume and severity distribution remain stable; Run 8 sits at the 8-run mean exactly. The "Corrector/Drafter introduces defects" pattern persists at 7/8 runs.
+This section compares Run 9 against all 8 prior runs to identify patterns that persist across documents. A single run is an anecdote; trends across 9 runs are signal.
 
 ### Finding counts and severity profiles across all runs
 
-| Run | Date | Document | CRITICAL | MAJOR | MINOR | Total | App rate | C1 regressions |
-|-----|------|----------|----------|-------|-------|-------|----------|----------------|
-| 1 -- Rate Limiter (fixture) | 2026-03-08 | Design doc (planted flaws) | 3 | 7 | 8 | 18 | 94% | 0 |
-| 2 -- E2E Bug Fix Plan | 2026-03-08 | Real bug fix plan | 2 | 6 | 7 | 15 | 93% | 1 |
-| 3 -- Phase 6 Plan | 2026-03-14 | Real implementation plan | 4 | 11 | 11 | 26 | 100% | ? |
-| 4 -- Post-MVP Plan | 2026-03-15 | Real implementation plan | 4 | 9 | 6 | 19 | 100% | 2 |
-| 5 -- Normalize Stage Plan | 2026-03-17 | Real implementation plan | 2 | 8 | 7 | 17 | 100% | 1 |
-| 6 -- Pipeline Failure Fix Plan | 2026-03-21 | Real fix plan | 3 | 7 | 8 | 18 | 94% | 1 |
-| 7 -- CI/CD Reference Guide | 2026-03-21 | Real reference doc | 3 | 8 | 9 | 20 | 100% | 2 |
-| **8 -- Pipeline Bug Fix Plan** | **2026-03-22** | **Real implementation plan** | **2** | **9** | **9** | **20** | **100%** | **1** |
+The columns: **Run** identifies the document. **CRITICAL/MAJOR/MINOR** are finding counts by severity. **Total** is the sum. **App rate** is the percentage of actionable findings applied. **Drafter reg.** and **C1 reg.** are regression counts for the Drafter and Corrector-1 respectively.
+
+| Run | Date | Document | CRITICAL | MAJOR | MINOR | Total | App rate | Drafter reg. | C1 reg. |
+|-----|------|----------|----------|-------|-------|-------|----------|-------------|---------|
+| 1 -- Rate Limiter (fixture) | 2026-03-08 | Design doc (planted flaws) | 3 | 7 | 8 | 18 | 94% | ? | 0 |
+| 2 -- E2E Bug Fix Plan | 2026-03-08 | Real bug fix plan | 2 | 6 | 7 | 15 | 93% | ? | 1 |
+| 3 -- Phase 6 Plan | 2026-03-14 | Real implementation plan | 4 | 11 | 11 | 26 | 100% | ? | ? |
+| 4 -- Post-MVP Plan | 2026-03-15 | Real implementation plan | 4 | 9 | 6 | 19 | 100% | ? | 2 |
+| 5 -- Normalize Stage Plan | 2026-03-17 | Real implementation plan | 2 | 8 | 7 | 17 | 100% | ? | 1 |
+| 6 -- Pipeline Failure Fix Plan | 2026-03-21 | Real fix plan | 3 | 7 | 8 | 18 | 94% | 0 | 1 |
+| 7 -- CI/CD Reference Guide | 2026-03-21 | Real reference doc | 3 | 8 | 9 | 20 | 100% | 2 | 2 |
+| 8 -- Pipeline Bug Fix Plan | 2026-03-22 | Real implementation plan | 2 | 9 | 9 | 20 | 100% | 2 | 1 |
+| **9 -- PRD Workflow Recommendation** | **2026-03-22** | **Real recommendation report** | **3** | **7** | **8** | **18** | **88%** | **2** | **1** |
+
+### Regression tracking table
+
+This table tracks defects introduced by the Drafter and Corrector-1 as first-class metrics. Higher numbers mean the stage is creating more work for downstream stages to clean up.
+
+| Run | Drafter regressions | Corrector-1 regressions | Evidence-gating compliance |
+|-----|--------------------|-----------------------|---------------------------|
+| 1 | ? | 0 | N/A (pre-evidence-gating) |
+| 2 | ? | 1 | N/A |
+| 3 | ? | ? | N/A |
+| 4 | ? | 2 | N/A |
+| 5 | ? | 1 | N/A |
+| 6 | 0 | 1 | N/A |
+| 7 | 2 | 2 | N/A |
+| 8 | 2 | 1 | N/A |
+| **9** | **2** | **1** | **82%** |
 
 ### What the numbers say
 
-1. **Finding counts: 18 -> 15 -> 26 -> 19 -> 17 -> 18 -> 20 -> 20.** The 8-run range remains 15-26. Run 8's 20 matches Run 7 exactly and sits at the updated mean of 19.1. No upward or downward trend -- volume tracks document complexity.
+1. **Finding counts: 18 -> 15 -> 26 -> 19 -> 17 -> 18 -> 20 -> 20 -> 18.** The 9-run range remains 15-26. Run 9's 18 is exactly the Run 1 count and sits just below the updated mean of 19.0. No trend -- volume continues to track document complexity.
 
-2. **CRITICAL counts: 3 -> 2 -> 4 -> 4 -> 2 -> 3 -> 3 -> 2.** Run 8's 2 CRITICALs is the joint-lowest with Run 2 and Run 5. Updated mean: 2.9 CRITICALs per run. Both Run 8 CRITICALs were high-quality: one was a logical design flaw (overlap guard category mismatch), the other was a compilation blocker (`config.projectRoot`). The lower count reflects that the Researcher front-loaded 2 compilation blockers (ensureDirSync, max-5 scope) that in prior runs might have surfaced as critic-found CRITICALs.
+2. **CRITICAL counts: 3 -> 2 -> 4 -> 4 -> 2 -> 3 -> 3 -> 2 -> 3.** Run 9 returns to 3 after Run 8's 2. However, 1 of the 3 was a false positive (Critic-2 falsely claimed KB citations were fabricated). Excluding the false positive: 2 genuine CRITICALs. Updated mean: 2.9 CRITICALs per run (raw), ~2.8 excluding known false positives. Both genuine CRITICALs were high-quality: the VALIDATE self-undermining contradiction and the NORMALIZE schema mismatch.
 
-3. **Application rate: 94% -> 93% -> 100% -> 100% -> 100% -> 94% -> 100% -> 100%.** Run 8 continues the 100% streak (3 consecutive). Updated mean: 97.6% across 8 runs.
+3. **Application rate: 94% -> 93% -> 100% -> 100% -> 100% -> 94% -> 100% -> 100% -> 88%.** Run 9 is the lowest application rate in the series. The 2 rejected findings were both rejected with documented rationale by Corrector-2, and 1 Critic-2 finding was a false positive. The 88% reflects legitimate editorial judgment, not noise -- but it breaks the 3-run 100% streak. Updated mean: 96.6%.
 
 4. **Severity distribution (% of total):**
 
-| Severity | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | Mean |
-|----------|-----|-----|-----|-----|-----|-----|-----|-----|------|
-| CRITICAL | 17% | 13% | 15% | 21% | 12% | 17% | 15% | 10% | 15% |
-| MAJOR | 39% | 40% | 42% | 47% | 47% | 39% | 40% | 45% | 42% |
-| MINOR | 44% | 47% | 42% | 32% | 41% | 44% | 45% | 45% | 43% |
+| Severity | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | Mean |
+|----------|-----|-----|-----|-----|-----|-----|-----|-----|-----|------|
+| CRITICAL | 17% | 13% | 15% | 21% | 12% | 17% | 15% | 10% | 17% | 15% |
+| MAJOR | 39% | 40% | 42% | 47% | 47% | 39% | 40% | 45% | 39% | 42% |
+| MINOR | 44% | 47% | 42% | 32% | 41% | 44% | 45% | 45% | 44% | 43% |
 
-Run 8's CRITICAL share (10%) dips below the prior band floor (12%). This is the first time CRITICAL % has gone below 12%. However, the absolute CRITICAL count (2) is within the 2-4 range seen before. The 10% is an artifact of high total findings (20) combined with only 2 CRITICALs. MAJOR and MINOR remain squarely within established bands.
+Run 9 snaps back to 17/39/44, matching Run 1 and Run 6 almost exactly. After Run 8's dip in CRITICAL share (10%), the distribution returns to the established center. Severity calibration remains stable across 9 runs.
 
-5. **Corrector-1 regression series: 0 -> 1 -> ? -> 2 -> 1 -> 1 -> 2 -> 1.** Run 8 returns to 1 after Run 7's 2. No improvement trend. 8-run mean (excluding Run 3): 1.1 regressions per run.
+5. **Corrector-1 regression series: 0 -> 1 -> ? -> 2 -> 1 -> 1 -> 2 -> 1 -> 1.** Run 9 holds at 1. Mean (excluding Run 3): 1.1 per run. No improvement trend.
 
-### Recurring finding types
+6. **Drafter regression series (Runs 6-9): 0 -> 2 -> 2 -> 2.** Three consecutive runs with 2 regressions each. Run 6's 0 looks like the outlier, not the norm.
 
-| Finding type | Runs present | Run 8 evidence |
+### Recurring finding types (patterns appearing in 2+ runs)
+
+| Finding type | Runs present | Run 9 evidence |
 |-------------|-------------|----------------|
-| **Corrector/Drafter introduces new defects** | **7/8** (all except R1) | Drafter introduced `config.projectRoot` type error and flawed overlap guard. Corrector-1 perpetuated `config.projectRoot` with false self-review. Both the Drafter and Corrector-1 independently claimed to verify a config field that does not exist. |
-| **False safety claims / incorrect verification** | **5/8** (R4, R5, R6, R7, R8) | Both Drafter (self-review item 1) and Corrector-1 (self-review item 1) claimed "verified `config.projectRoot` is available." It is not. This is the same false-verification pattern from R6 ("retry loop handles it") -- the claimed verification never happened. |
-| **Silent config/integration gaps** | **6/8** (R2, R3, R5, R6, R7, R8) | `config.projectRoot` does not exist in `HiveMindConfig`. Multi-module path resolution not handled. Sub-task impl reports missed by overlap guard. Import paths wrong for orchestrator directory. |
-| **Verification/test gaps** | **6/8** (R2, R4, R5, R6, R7, R8) | Zero test cases for salvage commit, overlap guard, or artifact preservation -- the riskiest new code. Critic-1 flagged this, leading to 6 new test cases. |
-| **Wrong directory / path errors** | **4/8** (R3, R5, R6, R8) | Multi-module `sourceFiles` paths relative to module root, not project root. Wrong relative import paths (`../utils/file-io.js` vs `./utils/file-io.js`). |
+| **Corrector/Drafter introduces new defects** | **8/9** (all except R1) | Drafter introduced wrong constitution path and unresolved VALIDATE contradiction. Corrector-1 introduced naive Gap 2 resolution ignoring schema mismatch. 3 total regressions across 2 stages. |
+| **False safety claims / incorrect verification** | **6/9** (R4-R9) | Corrector-1 inherited the Drafter's constitution path error (`constitution/` vs `constitution.md`) without verifying. The Drafter itself introduced the path by guessing rather than checking. Critic-2 produced a false positive claiming KB citations were fabricated. |
+| **Silent config/integration gaps** | **7/9** (R2, R3, R5-R9) | NORMALIZE agent expects 7 sections; document-guidelines template has 10. Constitution is a file (`constitution.md`), not a directory (`constitution/`). These schema mismatches were invisible to all stages until Critic-2. |
+| **Verification/test gaps** | **7/9** (R2, R4-R9) | The VALIDATE phase designs a 9-row validation table while simultaneously citing evidence (F2/F9) that such checks achieve only 17% compliance. No measurement plan for whether the proposed workflow improves PRD quality. |
+| **Wrong directory / path errors** | **5/9** (R3, R5, R6, R8, R9) | `/prd` skill references `.hive-mind/document-guidelines.md` but the file lives at `../.hive-mind-persist/document-guidelines.md`. Drafter wrote `constitution/` (directory) instead of `constitution.md` (file). |
+| **Critic produces false positive** | **2/9** (R9 new, R8 had false self-review) | Critic-2 Finding 1 falsely claimed all KB citations (P30, P28, F2, F9) were fabricated. They demonstrably exist. This is a new failure mode for the critic stage specifically -- prior runs had false verification by Drafter/Corrector, not by critics. |
 
 ### Is the pipeline finding fewer issues over time?
 
-No. Run 8 found 20 findings (above the 19.1 mean), including 2 CRITICALs. The meaningful signal remains: **every run on a real document finds at least 2 CRITICALs** (8/8 runs), and those CRITICALs are always specific to that document. The "false self-review verification" pattern (5/8 runs) is intensifying -- it appeared in 3 of the last 5 runs and was especially pronounced in Run 8 where two stages independently made the same false claim.
+No. Run 9 found 18 findings (just below the 19.0 mean), including 2 genuine CRITICALs (plus 1 false positive). Each run reviews a different document, so stable finding counts are expected. The meaningful signal remains: **every run on a real document finds at least 2 genuine CRITICALs** (9/9 runs). The "false verification/safety claims" pattern has now appeared in 6 of the last 6 runs (R4-R9) and is intensifying.
+
+### Is evidence-gating reducing false verification claims compared to pre-evidence-gating runs?
+
+Run 9 is the first run with the evidence-gating protocol explicitly in place (Drafter used `VERIFIED: <evidence>` format with file paths and line numbers). Result: **0 false verification claims from the Drafter** (13/13 accurate), and **0 false claims from Corrector-1** (5/5 direct claims accurate, 4 inherited without re-verification but all turned out correct). This is a positive initial signal, but it is a single data point. In the pre-evidence-gating Run 8, both Drafter and Corrector-1 fabricated verification of `config.projectRoot`. The evidence-gating protocol may have prevented that failure mode in Run 9 -- or Run 9's document may have been less prone to it. More runs needed to confirm.
+
+The evidence-gating protocol did NOT prevent Corrector-1 from inheriting claims without re-verification (4 claims). The protocol gap is real: Corrector-1 explicitly stated "I did not re-verify these as they were not modified in this correction pass." This is a compliance gap at 82% (18/22 claims had evidence). The 18% without evidence were inherited, not fabricated -- a less dangerous failure mode, but still a protocol violation.
 
 ---
 
 ## Stage Effectiveness Rankings
 
-| Stage | Contribution | Trend | Evidence (8 runs) |
+This section grades each pipeline stage like employees on a team: who is carrying weight, who is coasting, and who is improving or declining. Contribution is based on findings caught or value added. Trend compares recent runs to earlier runs.
+
+| Stage | Contribution | Trend | Evidence (9 runs) |
 |-------|-------------|-------|-------------------|
-| **Critic-2** | **HIGH** | **STABLE (peak)** | Run 8: 10 findings (1C/4M/5Mi), all new -- zero overlap with Critic-1. Found the `config.projectRoot` compilation blocker that both Drafter and Corrector-1 missed despite self-review. Across 8 runs: the only stage that has caught a compilation blocker in every run where one existed. Zero false positives. |
-| **Researcher** | **HIGH** | **STABLE** | Run 8: caught both `ensureDirSync` and max-5 scope errors (compilation blockers), killed ENV-TAGGING and `envRequires` as YAGNI, surfaced 4 knowledge-base cross-references. The extractor rates it "the single most valuable stage this run." Across 8 runs: zero false positives, highest foundational value. |
-| **Critic-1** | **HIGH** | **RECOVERING** | Run 8: 10 findings (1C/5M/4Mi) -- a solid result with 1 CRITICAL (overlap guard category mismatch). This confirms the Run 7 rebound from Run 6's 0-CRITICAL nadir. CRITICAL counts across runs: 2->1->1->2->1->0->2->1. Run 8's CRITICAL was a deep logical flaw requiring reasoning about runtime behavior, suggesting Critic-1 can find code-reasoning CRITICALs when the flaw is visible from document logic. |
-| **Corrector-2** | **HIGH** | **IMPROVING** | Run 8: 10/10 applied (100%), zero regressions. Made the architectural pivot to `plan-validator` agent -- the single largest quality improvement in the document. Expanded tests from 21 to 26. Across 8 runs: perfect application rate, 0 regressions ever, increasing creative contribution (file-content hashing in R6, YAML split in R7, plan-validator in R8). |
-| **Drafter** | **MEDIUM-HIGH** | **MIXED** | Run 8: self-caught 4 issues (empty commit, runShell syntax, missing try/catch, weak path guard) but introduced 2 defects (config.projectRoot, flawed overlap guard). Run 7 also had 2 regressions; Run 6 had 0. Regression series: unclear->unclear->unclear->unclear->unclear->0->2->2. Essential for volume but unreliable for accuracy. |
-| **Corrector-1** | **MEDIUM** | **STABLE (mediocre)** | Run 8: applied 10/10 findings but introduced 1 regression (false self-review on config.projectRoot). Regression series: 0->1->?->2->1->1->2->1. Mean 1.1 per run. No improvement despite retrospective recommendations in Runs 6 and 7. The "false self-review verification" pattern is now confirmed: in 3 of the last 5 runs, Corrector-1 (or Drafter) claimed to verify something that does not exist. |
-| **Justifier** | **LOW** | **N/A (absent Runs 5-8)** | Not present in Run 8. Four consecutive runs without Justifier, zero missed findings. Permanently deprecated. |
-| **Reader** | **LOW** | **STABLE (consistently low)** | Run 8: catalogued 9 claims, 13 implementation items, 11 test cases. Did not flag that `ensureDirSync` does not exist, did not evaluate whether max-5 scope claim was correct. 8/8 runs: zero evaluative contribution. The extractor notes it "did not evaluate whether any claims were wrong -- it faithfully transcribed." |
+| **Critic-2** | **HIGH** | **STABLE (peak), with a new risk** | Run 9: 9 findings (2C/4M/3Mi), including the most architecturally important discovery (NORMALIZE schema mismatch). But also produced a dangerous false positive (fabricated KB citations claim). This is the first time Critic-2 has introduced a false positive across 9 runs. Corrector-2 correctly rejected it, but if accepted, it would have stripped all KB citations from the document. Across 9 runs: still the most valuable critic stage overall, but Run 9 introduces a yellow flag. |
+| **Researcher** | **HIGH** | **STABLE** | Run 9: 10+ findings including P30 gap, F2/F9 warnings, path bug, cost data debunked, 6 missing failure mode specs. The extractor calls it "the most valuable single stage." Across 9 runs: zero false positives ever, highest foundational value. The only stage with a perfect accuracy record. |
+| **Critic-1** | **HIGH** | **STABLE** | Run 9: 9 findings (1C/3M/5Mi). Found the VALIDATE value-proposition contradiction -- the most important structural problem. This CRITICAL was a deep logical reasoning catch: the document designs a mechanism and simultaneously cites evidence that the mechanism does not work. CRITICAL count across runs: 2->1->1->2->1->0->2->1->1. Run 9 confirms the Run 7 rebound from Run 6's nadir. |
+| **Corrector-2** | **HIGH** | **IMPROVING** | Run 9: applied 7/9, correctly rejected 2 (including the false positive -- the single most important judgment call). Produced the three-option Gap 2 resolution table. Zero regressions. Across 9 runs: perfect accuracy (0 regressions ever), increasing judgment quality (file-content hashing R6, YAML split R7, plan-validator R8, false-positive rejection + Gap 2 table R9). The most reliable stage in the pipeline. |
+| **Drafter** | **MEDIUM-HIGH** | **DECLINING (slight)** | Run 9: integrated 10+ Researcher findings, added 13 evidence-gated claims with file paths. But introduced 2 regressions (wrong constitution path, unresolved VALIDATE contradiction). Regression series (R6-R9): 0->2->2->2. Three consecutive runs with 2 regressions. The Run 6 zero-regression result was the outlier. The Drafter does heavy volume work but reliably introduces 2 defects per run. |
+| **Corrector-1** | **MEDIUM** | **STABLE (mediocre)** | Run 9: applied 8/9 Critic-1 findings, but introduced 1 regression (naive Gap 2 resolution) and inherited the constitution path error without checking. Also skipped re-verification of 4 inherited KB claims. Regression series: 0->1->?->2->1->1->2->1->1. Mean: 1.1 per run. No improvement despite 3 retrospective recommendations. |
+| **Justifier** | **N/A** | **DEPRECATED** | Absent for 5 consecutive runs (R5-R9). Zero missed findings attributable to absence. Permanently removed from pipeline. |
+| **Reader** | **LOW** | **STABLE (zero value)** | Run 9: zero evaluative contribution. 9/9 runs with no original findings. The retrospective recommended dropping it or trialing evaluative instructions. Neither has happened. 9 runs of evidence is conclusive. |
 
 ---
 
 ## What's Working
 
-Pipeline behaviors that consistently produce value, with evidence from multiple runs.
+Pipeline behaviors that consistently produce value, with evidence from multiple runs. If a behavior has only 1-2 data points, that is noted.
 
-**1. Two critique rounds find fundamentally different bug classes (8/8 runs)**
-Run 8 is a textbook example: Critic-1 found the overlap guard category mismatch (a logical design flaw), Critic-2 found the `config.projectRoot` type error (a compilation blocker requiring codebase verification). Zero overlap in findings. Across 8 runs, the two critics have never found the same issue. This remains the pipeline's defining strength.
+**1. Two critique rounds find fundamentally different bug classes (9/9 runs)**
+Run 9 continues the pattern: Critic-1 found the VALIDATE value-proposition contradiction (a logical consistency flaw visible from document reasoning alone), Critic-2 found the NORMALIZE schema mismatch and constitution path error (architectural flaws requiring codebase verification). Zero overlap in findings across all 9 runs. This is the pipeline's defining strength.
 
-**2. Researcher front-loading prevents compilation blockers from reaching critics (8/8 runs)**
-In Run 8, the Researcher caught `ensureDirSync` (does not exist) and the max-5 universal scope -- both would have been CRITICAL-grade findings if they reached the critics. By resolving them early, the Researcher freed Critic-1 and Critic-2 to focus on deeper design flaws (overlap guard, config type errors) rather than surface-level fact-checking. This may explain why Run 8's CRITICAL count (2) is lower than average (2.9) -- the Researcher front-loaded issues that in prior runs surfaced as critic CRITICALs.
+**2. Researcher front-loading prevents dozens of errors from entering the document (9/9 runs)**
+In Run 9, the Researcher surfaced P30, F2/F9, the path bug, cost data problems, 6 omitted PRD examples, and 6 missing failure mode specs -- all before the Drafter touched the document. The extractor notes that "nearly everything downstream built on this foundation." Across 9 runs: zero false positives ever, 4-15 pre-critic findings per run.
 
-**3. Corrector-2 is producing increasingly creative architectural solutions (Runs 5-8)**
-Run 8: `plan-validator` agent replacing rule-merge compromise. Run 7: YAML block split and `branches-ignore` promotion. Run 6: file-content hashing replacing `git diff`. Run 5: 3 self-catches. In 4 consecutive runs, Corrector-2 has done more than mechanically apply fixes -- it has redesigned approaches when critic analysis revealed fundamental problems. Zero regressions across all 8 runs.
+**3. Corrector-2 is the most reliable stage in the pipeline (9/9 runs, 0 regressions)**
+Run 9: correctly rejected the false positive (Finding 1) after independent verification, produced the three-option Gap 2 table. Across 9 runs: perfect application rate on accepted findings, zero regressions ever, increasingly sophisticated judgment calls (R6: file hashing, R7: YAML split, R8: plan-validator, R9: false-positive rejection). No other stage has a perfect record.
 
-**4. Severity calibration remains stable across 8 runs**
-CRITICAL: 10-21% (mean 15%). MAJOR: 39-47% (mean 42%). MINOR: 32-47% (mean 43%). Run 8's CRITICAL share (10%) is a minor dip below the prior floor (12%) but not an outlier -- it reflects strong Researcher front-loading rather than severity miscalibration. MAJOR and MINOR bands are unchanged.
+**4. Evidence-gating produced 0 false verification claims in its first run (1 data point)**
+Run 9 is the first run with the `VERIFIED: <evidence>` protocol. The Drafter made 13 verification claims with file paths and line numbers; all 13 were independently confirmed accurate. In the prior run (R8, pre-evidence-gating), both Drafter and Corrector-1 fabricated verification of `config.projectRoot`. The protocol may have prevented a similar failure in Run 9 -- but this is a single data point, not a trend.
 
-**5. Application rate at 100% for 3 consecutive runs**
-Runs 6 through 8: 100%, 100%, 100%. Updated 8-run mean: 97.6%. The pipeline produces findings that are overwhelmingly accepted as valid corrections. No noise.
+**5. Severity calibration remains stable across 9 runs**
+CRITICAL: 10-21% (mean 15%). MAJOR: 39-47% (mean 42%). MINOR: 32-47% (mean 43%). Run 9 sits at 17/39/44, matching the established center. Severity ratings remain meaningful for cross-run comparison.
 
 ---
 
 ## What's Not Working
 
-Pipeline behaviors that consistently underperform or add no value.
+Pipeline behaviors that consistently underperform or add no value. Every claim below cites a number from an actual run.
 
-**1. False self-review verification is the pipeline's most dangerous failure mode (5/8 runs)**
-Run 8 is the worst example yet: both the Drafter (self-review item 1) and Corrector-1 (self-review item 1) independently claimed to verify that `config.projectRoot` exists in `HiveMindConfig`. It does not. This is not a miss -- it is a false positive claim of verification. The same pattern appeared in Run 6 ("retry loop handles it") and Run 7 (Corrector-1 dismissed a valid self-review finding). When an agent claims to have verified something it has not, downstream stages treat the claim as authoritative. This is worse than not checking at all, because it creates false confidence.
+**1. Drafter regression rate has settled at 2 per run (Runs 7-9: 2, 2, 2)**
+Three consecutive runs with exactly 2 Drafter regressions. Run 9: wrong constitution path (guessed `constitution/` instead of verifying `constitution.md`) and unresolved VALIDATE contradiction (included both the mechanism and the evidence against it without reconciling). The Run 6 zero-regression result was the outlier, not the norm. The hypothesis that stronger Researcher input reduces Drafter regressions is not supported across 4 data points (R6-R9).
 
-**2. Corrector-1 defect introduction rate is unchanged (7/8 runs)**
-Regression series: 0 -> 1 -> ? -> 2 -> 1 -> 1 -> 2 -> 1. Mean: 1.1 per run. The retrospective-2026-03-21.md recommended adding "verify against actual codebase" instructions. The retrospective-2026-03-21-r2.md recommended tracking regressions as a first-class metric. Neither has measurably reduced the rate. This is the pipeline's most persistent structural weakness.
+**2. Corrector-1 regression rate is structurally unchanged (mean 1.1/run across 9 runs)**
+Run 9: 1 regression (naive Gap 2 resolution ignoring schema mismatch). Series: 0->1->?->2->1->1->2->1->1. Three retrospective recommendations (Runs 6, 7, 8) have not measurably reduced this rate. Prompt-level instructions are insufficient per F2 (behavioral prose without consequences achieves 17% compliance).
 
-**3. Drafter introduces defects at a consistent rate (Runs 6-8 pattern: 0 -> 2 -> 2)**
-The hypothesis from Run 6 (stronger Researcher input reduces Drafter regressions) was tested across 3 runs: Run 6 had the strongest Researcher contribution and 0 Drafter regressions, but Runs 7 and 8 also had strong Researcher input and 2 Drafter regressions each. The hypothesis is not supported (n=3). The Drafter reliably introduces 1-2 new defects per run regardless of input quality.
+**3. Critic-2 produced its first false positive in 9 runs**
+Run 9's Finding 1 claimed all knowledge-base citations (P30, P28, F2, F9) were fabricated and KB files were empty. All four entries demonstrably exist at the cited locations. The extractor calls this "a significant error" and notes it "nearly damaged the document." This is the first time a critic stage (as opposed to Drafter/Corrector) has produced a false positive. If Corrector-2 had not independently verified, the document would have lost all its supporting evidence. This is a new risk that did not exist in Runs 1-8.
 
-**4. Reader remains zero-value for finding discovery (8/8 runs)**
-Eight runs, zero original findings. Run 8's extractor explicitly states the Reader "did not evaluate whether any claims were wrong." The retrospective-2026-03-21-r2.md recommended trialing evaluative instructions for Run 8; this does not appear to have been implemented. The Reader continues to produce structured inventory that the Researcher could build itself. Eight runs of evidence is more than sufficient for a decision.
+**4. Corrector-1 inherits verification claims without re-checking (Run 9: 4 inherited claims at 0% re-verification)**
+Corrector-1 explicitly stated: "I did not re-verify these as they were not modified in this correction pass." This produced 82% evidence-gating compliance instead of 100%. While the inherited claims happened to be accurate in Run 9, this protocol gap is the exact mechanism that caused failures in Runs 6-8 (propagated false claims). The evidence-gating protocol needs enforcement at the Corrector-1 level, not just the Drafter level.
+
+**5. Reader remains zero-value for finding discovery (9/9 runs)**
+Nine runs, zero original findings. The retrospective recommended dropping Reader or trialing evaluative instructions after Run 8. Neither has been implemented. The Reader's structured inventory gives downstream stages a checklist, but the Researcher builds its own more thorough checklist. Nine runs is conclusive.
 
 ---
 
 ## So What?
 
-- **Run 8 confirms the pipeline catches real bugs: 2 CRITICALs (overlap guard category mismatch, config.projectRoot compilation blocker), 9 MAJORs, and the plan went from 11 test cases to 26.** Across 8 runs, the pipeline averages 2.9 CRITICALs per run with 97.6% application rate. Every run on a real document has found at least 2 CRITICALs.
+These are the 5 things a team lead should know about the pipeline's health after 9 runs.
 
-- **False self-review verification is now the top-priority failure mode.** In Run 8, two stages independently claimed to verify a nonexistent config field. This is worse than missing an issue -- it creates false confidence that propagates downstream. 5 of the last 8 runs have this pattern. Fix: replace self-review "I verified X" claims with tool-assisted verification (e.g., require the Corrector to output the actual line of code it found, not just assert it exists).
+- **The pipeline continues to catch real bugs: 2 genuine CRITICALs in Run 9 (VALIDATE self-undermining, NORMALIZE schema mismatch), plus 7 MAJORs.** Across 9 runs, the pipeline averages 2.9 CRITICALs per run with 96.6% application rate. Every run on a real document has found at least 2 genuine CRITICALs. The pipeline generalizes across 5 document types (design docs, fix plans, implementation plans, reference guides, recommendation reports).
 
-- **Corrector-2's architectural creativity is a growing asset.** Three consecutive runs with non-trivial design improvements (file hashing, YAML split, plan-validator agent). This stage is not just fixing bugs -- it is improving the overall design quality of the final document.
+- **Evidence-gating shows promise in its first run: 0 false verification claims vs. Run 8's 2 fabricated claims.** But this is 1 data point. The protocol has a gap: Corrector-1 skipped re-verification of inherited claims (82% compliance, not 100%). The next run should enforce re-verification at the Corrector-1 level and track whether the 0-false-claim result holds.
 
-- **The Reader stage decision is overdue.** Eight runs of zero evaluative contribution. The retrospective recommended trialing evaluative instructions or dropping the stage. That trial should happen in Run 9 or the Reader should be permanently removed.
+- **Critic-2 produced its first-ever false positive, creating a new risk category.** In 8 prior runs, critics had never generated a false positive -- only Drafter/Corrector stages had that failure mode. Run 9's Critic-2 falsely claimed KB citations were fabricated. Corrector-2 correctly rejected it, but this relies on Corrector-2's judgment. If Corrector-2 had accepted, the document would have lost all supporting evidence. Monitor whether this recurs.
 
-- **Corrector-1 regression rate (mean 1.1/run) has not responded to two retrospective recommendations.** Prompt-level instructions are not sufficient. Consider structural changes: either give Corrector-1 explicit tool access for codebase verification, or add a lightweight pre-Critic-2 validation step that checks function signatures and import paths programmatically.
+- **Drafter and Corrector-1 regression rates are structural, not prompt-fixable.** Drafter: 2/run for 3 consecutive runs. Corrector-1: mean 1.1/run across 9 runs, unchanged by 3 retrospective recommendations. Accept these as pipeline costs that Critic-2 and Corrector-2 absorb, or make structural changes (tool access for codebase verification, automated pre-validation).
+
+- **The Reader stage decision is now 9 runs overdue.** Zero evaluative findings in 9 runs. Drop it or merge its inventory function into the Researcher prompt. Every run it remains is wasted tokens with no demonstrated value.

--- a/tests/double-critique/retrospective-2026-03-22.md
+++ b/tests/double-critique/retrospective-2026-03-22.md
@@ -1,118 +1,132 @@
 # Double-Critique Pipeline -- Retrospective Report
 
-**Date:** 2026-03-22
-**Runs covered:** 8 (Run 1 through Run 8, 2026-03-08 to 2026-03-22)
-**Based on:** effectiveness-2026-03-22.md
-**Prior retrospective:** retrospective-2026-03-21-r2.md (covered Runs 1-7)
+**Date:** 2026-03-22 (updated after Run 9)
+**Runs covered:** 9 (Run 1 through Run 9, 2026-03-08 to 2026-03-22)
+**Based on:** effectiveness-2026-03-22.md (Run 9 -- PRD workflow recommendation)
+**Prior retrospective:** retrospective-2026-03-21-r2.md (covered Runs 1-7), this file's prior version (covered Runs 1-8)
 
 ---
 
 ## Summary
 
-Run 8 confirms the pipeline's core value proposition (2 CRITICALs caught, 100% application rate, test cases expanded from 11 to 26) while surfacing false self-review verification as the top-priority failure mode -- two stages independently claimed to verify a config field that does not exist. The Researcher earned "single most valuable stage this run" by front-loading two compilation blockers, and Corrector-2 made an architectural pivot to a plan-validator agent that improved the final design. The Reader stage produced zero original findings for the 8th consecutive run -- the trial of evaluative instructions either did not happen or did not work.
+What is this report? This is a team retrospective -- like a post-game huddle where we decide what to keep doing, what to change, and what to stop doing. It covers 9 pipeline runs across 5 document types (design docs, fix plans, implementation plans, reference guides, recommendation reports) and distills them into actionable next steps. Run 9 validated the evidence-gating protocol (0 false Drafter verification claims), surfaced a new risk category (critic-originated false positive), and confirmed that Reader, Corrector-1 regression rate, and Drafter regression rate remain structurally unchanged despite repeated retrospective recommendations.
 
 ---
 
 ## KEEP -- What's Working Well
 
-- **Two-round critique architecture (8/8 runs, zero overlap)** -- Critic-1 found the overlap guard category mismatch (logical design flaw); Critic-2 found the `config.projectRoot` compilation blocker (type error requiring codebase verification). Zero finding overlap across all 8 runs. This is the pipeline's defining strength and the single clearest signal in the data. -- Action: Continue as-is. No changes.
+- **Two-round critique architecture** -- Two independent critics find fundamentally different bug classes, with zero finding overlap across 9 runs. -- Evidence: 9/9 runs complementary. Run 9: Critic-1 found VALIDATE value-proposition contradiction (logical consistency); Critic-2 found NORMALIZE schema mismatch (architectural). Mean 2.9 genuine CRITICALs/run. Every run on a real document finds at least 2 genuine CRITICALs. -- Action: Keep unchanged. Do not merge critics into a single pass.
 
-- **Researcher front-loading (8/8 runs, zero false positives)** -- Run 8: caught `ensureDirSync` (nonexistent function) and max-5 universal scope (applies to all 37 agent types, not just refactorer), killed YAGNI items (ENV-TAGGING, `envRequires`), surfaced 4 knowledge-base cross-references. The effectiveness report calls it "the single most valuable stage this run." These front-loaded fixes likely explain Run 8's lower CRITICAL count (2 vs 2.9 mean) -- issues that would have surfaced as critic CRITICALs were resolved early. -- Action: Continue as-is.
+- **Researcher front-loading** -- Reads KB, cross-references codebase, surfaces factual problems before critics see the document. Zero false positives in 9 runs. -- Evidence: 9/9 runs, 4-15 pre-critic findings/run. Run 9: 10+ findings including debunked cost data ($10-40 vs actual ~$0.10), path bugs, 6 omitted PRD examples, 6 missing failure mode specs. Called "the most valuable single stage" in Run 9. Perfect accuracy record (only stage with zero false positives ever). -- Action: Keep as-is.
 
-- **Corrector-2 creative architectural solutions (Runs 5-8, zero regressions ever)** -- Run 8: pivoted to `plan-validator` agent when critic analysis revealed the rule-merge approach was fundamentally compromised. Run 7: YAML block split. Run 6: file-content hashing. Run 5: 3 self-catches. Corrector-2 is not just fixing bugs -- it is redesigning approaches when the critic evidence warrants it. Zero regressions across all 8 runs. -- Action: Continue as-is. This stage is peak performing.
+- **Corrector-2 as pipeline safety net** -- Final corrector applies findings with zero regressions across all 9 runs, exercising increasingly sophisticated editorial judgment. -- Evidence: 0 regressions in 9 runs. Run 9: correctly rejected Critic-2's dangerous false positive (fabricated KB citations claim) after independent verification. Judgment progression: self-catches (R5), file-content hashing (R6), YAML split (R7), plan-validator pivot (R8), false-positive rejection + three-option Gap 2 table (R9). Most reliable stage in the pipeline. -- Action: Keep as final stage.
 
-- **Severity calibration stability (8 runs)** -- CRITICAL: 10-21% (mean 15%). MAJOR: 39-47% (mean 42%). MINOR: 32-47% (mean 43%). Run 8's CRITICAL share (10%) dips below the prior floor (12%) but the absolute count (2) is within the 2-4 range. The dip reflects Researcher front-loading, not miscalibration. -- Action: Continue as-is. Monitor if CRITICAL % stays below 12% for 2+ runs.
+- **Severity calibration stability** -- CRITICAL/MAJOR/MINOR distribution remains consistent across 9 runs and 5 document types. -- Evidence: CRITICAL 10-21% (mean 15%), MAJOR 39-47% (mean 42%), MINOR 32-47% (mean 43%). Run 9: 17/39/44, matching Runs 1 and 6 exactly. -- Action: No change needed.
 
-- **100% application rate (3 consecutive runs)** -- Runs 6-8 all at 100%. 8-run mean: 97.6%. The pipeline produces findings that are overwhelmingly accepted as valid corrections. Zero noise. -- Action: Continue as-is.
+- **Evidence-gating protocol (first run, promising)** -- The VERIFIED:<evidence> format eliminated fabricated Drafter verification claims in its first outing. -- Evidence: Run 9: 13/13 Drafter verification claims accurate with file paths and line numbers. Run 8 (pre-protocol): both Drafter and Corrector-1 fabricated `config.projectRoot` verification. 0 false claims vs 2+ in prior run. -- Action: Keep protocol. Extend enforcement to Corrector-1 (see CHANGE).
 
-- **7-stage pipeline (no Justifier, 4 consecutive runs)** -- Runs 5-8 without Justifier, zero missed finding types. Confirmed permanent default. -- Action: Formally document as the standard pipeline configuration.
+- **Application rate** -- Pipeline produces findings that are overwhelmingly accepted as valid corrections. -- Evidence: 9-run mean: 96.6%. Run 9 dipped to 88% (lowest in series), but both rejections were well-reasoned by Corrector-2 with documented rationale, and 1 Critic-2 finding was a false positive excluded from the actionable count. -- Action: Continue as-is.
 
 ---
 
 ## CHANGE -- What Should Be Modified
 
-- **False self-review verification must be replaced with evidence-based verification (5/8 runs)** -- Run 8 is the worst instance yet: both Drafter (self-review item 1) and Corrector-1 (self-review item 1) independently claimed "verified `config.projectRoot` is available in HiveMindConfig." It is not. This is not a miss -- it is a fabricated verification claim. The same pattern appeared in Runs 4, 5, 6, and 7. When an agent claims to have verified something it has not, downstream stages treat the claim as authoritative. This is worse than not checking at all. -- Evidence: 5/8 runs, including 3 of the last 5. Run 6: "retry loop handles it." Run 7: Corrector-1 dismissed valid self-review. Run 8: two stages independently fabricated the same verification. -- Action: Replace "I verified X" self-review with tool-assisted verification. Corrector-1 and Drafter prompts must require: "For every verification claim, output the actual line of code or config field you found. If you cannot paste the evidence, state 'UNVERIFIED' instead of claiming verification." This is a Tier 2 enforcement change (require an artifact, per P11).
+- **Corrector-1 must re-verify inherited claims** -- Corrector-1 inherits Drafter verification claims without checking them, creating a protocol gap at 82% compliance. -- Evidence: Run 9: 4 claims inherited at 0% re-verification. Corrector-1 explicitly stated "I did not re-verify these as they were not modified in this correction pass." This is the exact mechanism that caused false verification in Runs 6-8 (`config.projectRoot`). The evidence-gating format (Tier 2) works, but the independence requirement (Tier 4) does not -- 86pp gap per P13. -- Action: Add to Corrector-1 prompt: "Every factual claim you carry forward must have a VERIFIED: tag with your own evidence. Inherited Drafter tags are not valid for your output. If you cannot verify, mark UNVERIFIED: inherited."
 
-- **Corrector-1 defect rate is structurally unchanged despite 2 retrospective recommendations (7/8 runs)** -- Regression series: 0->1->?->2->1->1->2->1. Mean: 1.1 per run. The retrospective-2026-03-21.md recommended adding "verify against actual codebase" instructions. The retrospective-2026-03-21-r2.md recommended tracking regressions as a first-class metric. Neither has measurably reduced the rate. Prompt-level instructions are insufficient (aligns with F2: behavioral prose without consequences has 17% compliance). -- Evidence: 8-run regression series with no improvement trend. -- Action: Consider structural changes rather than more prompt instructions: (1) give Corrector-1 explicit tool access for codebase verification (Grep/Read), or (2) add a lightweight automated pre-Critic-2 validation step that checks function signatures and import paths programmatically. If neither is feasible, accept 1.1 regressions/run as a structural cost that Critic-2 absorbs.
+- **Drafter regression rate needs structural intervention, not more prompts** -- Three consecutive runs (7-9) with exactly 2 regressions each. Prompt changes have not helped. -- Evidence: Drafter regression series (R6-R9): 0, 2, 2, 2. Run 9: wrong constitution path (guessed `constitution/` instead of `constitution.md`) and unresolved VALIDATE contradiction. Run 6's zero was the outlier. -- Action: Add a mechanical self-check: before outputting, the Drafter must run `ls` or `cat` on any new file paths it introduces (converts path verification from Tier 4 to Tier 2). For logical contradictions, add an explicit output section: "## Contradictions Check."
 
-- **Drafter defect introduction is consistent (Runs 7-8: 2 regressions each)** -- The hypothesis from Run 6 (stronger Researcher input reduces Drafter regressions) is not supported (n=3). Run 6 had 0 regressions, Runs 7-8 had 2 each, despite equally strong Researcher input. The Drafter reliably introduces 1-2 new defects per run regardless of input quality. -- Evidence: Drafter regression series (Runs 6-8): 0->2->2. -- Action: Accept Drafter defect introduction as structural. The pipeline's value is that critics catch these defects. Do not invest further in preventing them -- invest in catching them faster.
+- **Critic-2 needs a citation verification requirement** -- Produced its first-ever false positive in Run 9, claiming KB citations were fabricated when they demonstrably exist. -- Evidence: Run 9 Finding 1: claimed P30, P28, F2, F9 were fabricated and KB files were empty. All four entries exist. If Corrector-2 had accepted, the document would have lost all supporting evidence. First critic-originated false positive in 9 runs. -- Action: Add to Critic-2 prompt: "Before claiming a citation is fabricated, you MUST read the cited file and confirm the entry does not exist. Cite file path and line number as evidence of absence."
+
+- **Corrector-1 regression rate is structurally unchanged** -- Mean 1.1 regressions/run across 9 runs. Three retrospective recommendations have not measurably reduced this rate. This is F2 in action. -- Evidence: Series: 0, 1, ?, 2, 1, 1, 2, 1, 1. No improvement trend across 9 runs. -- Action: Stop recommending prompt changes. Consider structural changes: (1) give Corrector-1 codebase read access for path/type verification, or (2) add a lightweight diff-checker between Corrector-1 input/output that flags new terms introduced without evidence. If neither is feasible, accept 1.1/run as a structural pipeline cost.
 
 ---
 
 ## ADD -- New Pipeline Stages or Modifications to Try
 
-- **Evidence-gated self-review for Corrector-1 and Drafter** -- Replace free-text "I verified X" claims with structured evidence blocks: `VERIFIED: <field/function> found at <file:line>` or `UNVERIFIED: could not locate <field/function>`. This converts a Tier 4 check (behavioral prose) into a Tier 2 check (artifact requirement). -- Evidence: False verification is now confirmed at 5/8 runs and intensifying (Run 8 had the worst instance with two independent false claims). -- Action: Implement in Run 9. Measure: count of `UNVERIFIED` tags produced vs false verification claims that reach Critic-2.
+- **Evidence-gating enforcement at Corrector-1 level** -- Extend the VERIFIED:<evidence> protocol to Corrector-1. The protocol worked at Drafter level (0 false claims) but was not enforced at Corrector-1 (82% compliance). -- Action: In Corrector-1 prompt, require: "Every factual claim you carry forward must have a VERIFIED: tag with your own evidence." Track compliance rate in Run 10 effectiveness report.
 
-- **Corrector-1 regression count as tracked metric (carry-forward from R2 retro)** -- This was recommended in the prior retrospective but not yet implemented. The regression series (0->1->?->2->1->1->2->1) is reconstructed from narrative analysis each time. -- Action: Add `corrector1_regressions` and `drafter_regressions` as fields in the effectiveness report template for Run 9.
-
-- **Reader stage: final decision** -- Run 8 was supposed to trial evaluative instructions per the R2 retrospective recommendation. The effectiveness report states the Reader "did not evaluate whether any claims were wrong -- it faithfully transcribed." Either the trial was not implemented or it produced zero effect. Eight runs of zero evaluative contribution is conclusive. -- Action: Drop Reader from Run 9. If the Reader's structured inventory is needed, fold it into the Researcher prompt as a pre-step. Save one full stage of tokens.
+- **Monitor Critic false-positive rate as a tracked metric** -- Run 9 introduced a new risk category: critic-originated false positives. -- Action: Add a "Critic false positives" row to the regression tracking table. Track count per run starting Run 10.
 
 ---
 
 ## DROP -- Not Pulling Its Weight
 
-- **Reader stage (confirmed drop after 8 runs)** -- Eight consecutive runs with zero original findings. The effectiveness report explicitly states it "did not evaluate whether any claim was wrong." The R2 retrospective recommended trialing evaluative instructions or dropping it. The trial either did not happen or failed. Eight runs is more than sufficient data. -- Evidence: 8/8 runs, zero evaluative contribution. -- Action: Permanently remove from pipeline. If structured inventory has value, merge into Researcher prompt.
+- **Reader stage (9/9 runs, zero evaluative findings)** -- The Reader produces a structured document inventory but has never generated an original evaluative finding. The Researcher builds a more thorough inventory on its own. Two prior retrospective recommendations (evaluative instructions trial, consider dropping) were never acted on. Nine runs is conclusive. -- Evidence: 9 consecutive runs, 0 evaluative contributions. -- Action: Drop from Run 10 entirely. If downstream stages report degradation (unlikely), re-add. Estimated savings: one full agent spawn per run.
 
-- **Justifier stage (previously confirmed drop, 4 consecutive runs absent)** -- Runs 5-8 without Justifier, zero quality loss. Already formally deprecated. -- Action: Remove from documentation if still referenced anywhere.
+- **Justifier stage (confirmed drop, 5 consecutive runs absent)** -- Absent for Runs 5-9 with zero missed findings. Every Justifier finding when present was a restatement of Researcher findings. -- Action: Confirm permanent removal. Remove from documentation if still referenced.
 
 ---
 
 ## NEW PATTERNS -- Candidate Patterns Discovered
 
-### False Self-Review Verification as Propagating Failure Mode
+### Last reviewer catches the most important judgment call
 
-- **What:** When a Drafter or Corrector claims "I verified X exists" without actually checking, downstream stages treat the claim as authoritative and stop looking. The false claim propagates through the entire pipeline until an independent critic with different verification methods catches it.
-- **Why:** Self-review creates a conflict of interest (F9). The agent that authored the change has implicit incentive to confirm its own work. Combined with F2 (prose without consequences), "I verified" is a costless claim with no enforcement.
-- **Evidence:** 5/8 runs. Run 8: Drafter and Corrector-1 both independently claimed `config.projectRoot` exists -- it does not. Run 6: "retry loop handles it" (it does not). Run 7: Corrector-1 dismissed valid self-review finding.
-- **Generalizability:** Applies to any multi-stage pipeline where an upstream stage's verification claim is trusted by downstream stages. The fix is Tier 2 enforcement: require the verification artifact (the actual code line), not just the claim.
+- **Plain-language name:** The final pair of eyes has no emotional investment
+- **What:** Corrector-2, as the final stage, is uniquely positioned to catch false positives from upstream critics because it reads the entire pipeline output cold and can independently verify claims without sunk-cost bias.
+- **Why:** By the time Corrector-2 runs, all other stages have committed to their positions. Corrector-2 has no authorship stake in any prior finding -- it can objectively evaluate whether a critic's claim is valid.
+- **Evidence:** Run 9: Critic-2 falsely claimed all KB citations (P30, P28, F2, F9) were fabricated. Corrector-2 independently verified the citations existed and correctly rejected the finding. Without this rejection, the document would have lost all supporting evidence.
+- **Analogy:** Like a final quality inspector on an assembly line who catches a previous inspector's mis-tag -- the last set of eyes has no emotional investment in any prior station's work.
 
-### Researcher Front-Loading Shifts CRITICAL Distribution Downward
+### Evidence-gating prevents fabrication but not inheritance
 
-- **What:** When the Researcher catches compilation blockers early, the CRITICAL count at critic stages drops because the CRITICALs that would have been found by critics are already resolved. The total bug-finding value is unchanged -- it shifts earlier in the pipeline.
-- **Why:** Researcher operates before drafting, so its finds never enter the finding count. This creates an illusion that the pipeline is finding "fewer CRITICALs" when in fact the pipeline's total value (Researcher + Critics) is constant or increasing.
-- **Evidence:** Run 8: 2 CRITICALs (lowest tied with Runs 2 and 5), but Researcher front-loaded 2 compilation blockers (ensureDirSync, max-5 scope) that would have been CRITICAL-grade if they reached critics. CRITICAL % dropped to 10% (below prior floor of 12%).
-- **Generalizability:** For any multi-stage quality pipeline, front-loading stages reduce downstream finding counts. Track total pipeline value (all stages combined), not just critic-stage findings.
+- **Plain-language name:** Receipts stop lying but not copying
+- **What:** Requiring `VERIFIED: <file:line>` format eliminated fabricated verification claims from the Drafter (0 false claims) but did not prevent Corrector-1 from carrying forward those claims without re-checking.
+- **Why:** The format requirement is Tier 2 enforcement (mechanical -- either the tag exists or not). The independence requirement (re-verify, do not inherit) is Tier 4 (behavioral prose). These two enforcement tiers have an 86pp compliance gap (P13).
+- **Evidence:** Run 9: Drafter 13/13 accurate (Tier 2 format enforcement). Corrector-1: 4 claims inherited at 0% re-verification (Tier 4 behavioral expectation). Overall compliance: 82%.
+- **Analogy:** Like requiring receipts for expense reports -- the receipt format is easy to enforce, but checking whether someone actually bought what the receipt says requires a second verification step that nobody does unless forced.
+
+### Critics can produce false positives too
+
+- **Plain-language name:** The reviewer who did not read the source
+- **What:** For the first time in 9 runs, a critic (not a Drafter or Corrector) generated a false positive -- falsely claiming knowledge-base citations were fabricated.
+- **Why:** Critics may infer file contents rather than reading them, leading to confident but wrong conclusions about whether referenced entries exist.
+- **Evidence:** Run 9 Critic-2 Finding 1: claimed P30, P28, F2, F9 were fabricated. All four demonstrably exist at cited locations. Prior false positives (Runs 4-8) were exclusively from Drafter/Corrector stages.
+- **Analogy:** Like a code reviewer commenting "this function doesn't exist" without actually searching the codebase -- the reviewer assumed rather than checked.
 
 ---
 
 ## NEW ANTI-PATTERNS -- Candidate Anti-Patterns Discovered
 
-### Cascading False Verification Claims Across Pipeline Stages
+### Inherited verification without re-checking
 
-- **What:** Two or more stages independently fabricate the same verification claim. Each stage's claim reinforces the others, creating compounding false confidence that makes the defect harder to catch.
-- **Why it fails:** When one stage claims "verified," the next stage is less likely to re-check. When two stages both claim "verified," the signal is even stronger -- and completely wrong. The defect becomes invisible until an independent cold-read critic (Critic-2) examines it without prior claims.
-- **Evidence:** Run 8: Drafter self-review item 1 stated "verified `config.projectRoot` is available." Corrector-1 self-review item 1 stated the same. Neither checked. Critic-2 found the field does not exist in `HiveMindConfig`.
-- **Fix:** Require evidence artifacts (actual code lines) for verification claims. A claim without evidence is treated as UNVERIFIED, not VERIFIED.
+- **Plain-language name:** Trusting the previous shift's checklist
+- **What:** A downstream stage carries forward verification claims from an upstream stage without independently re-verifying them, treating them as pre-validated.
+- **Why:** Corrector-1 optimizes for applying critic findings and treats unmodified Drafter claims as "not my responsibility." The evidence-gating protocol required evidence for new claims but did not explicitly require re-verification of inherited ones.
+- **Evidence:** Run 9: Corrector-1 stated "I did not re-verify these as they were not modified in this correction pass." 4 inherited claims, 0% re-verification. In Runs 6-8, the same mechanism caused propagation of false claims (`config.projectRoot`).
+- **Analogy:** Like a relay race where the second runner assumes the baton is the right one because the first runner handed it over confidently -- nobody re-checks the baton at the handoff.
 
-### Prompt-Level Instructions Ineffective Against Structural Pipeline Weaknesses
+### Critic asserting absence without reading the source
 
-- **What:** Adding behavioral instructions to Corrector-1's prompt ("verify against actual codebase") has not reduced its regression rate across 2 retrospective cycles.
-- **Why it fails:** This is a specific instance of F2 (behavioral prose without consequences). The instruction is Tier 4 enforcement in a context where Tier 2 (tool-call constraints or required artifacts) is needed.
-- **Evidence:** Corrector-1 regression rate: mean 1.1/run across 8 runs. Two retrospective recommendations (Runs 6 and 7) added prompt instructions. No measurable improvement.
-- **Fix:** Structural changes: tool access for codebase verification, or automated pre-validation step. Prompt instructions alone are insufficient for this failure mode.
+- **Plain-language name:** Claiming something does not exist without looking
+- **What:** A critic claims citations are fabricated without reading the cited files to confirm the entries do not exist.
+- **Why:** Critics receive document text but may not access (or choose to read) referenced files. They infer file contents from context clues rather than verifying directly.
+- **Evidence:** Run 9 Critic-2 Finding 1: "all KB citations are fabricated." P30, P28, F2, F9 all exist at cited locations. First critic-originated false positive in 9 runs.
+- **Analogy:** Like a fact-checker marking a quote as "made up" without calling the person who supposedly said it -- asserting absence requires the same evidence standard as asserting presence.
 
 ---
 
 ## Knowledge Base Graduation Assessment
 
-Four candidate findings assessed against the three criteria (stability: 3+ runs, evidence: measured numbers, generalizability: applies beyond double-critique):
+Five candidate findings assessed against the three criteria (stability: 3+ runs, evidence: measured numbers, generalizability: applies beyond double-critique):
 
-1. **False self-review verification (5/8 runs, intensifying)** -- Stability: YES (5 runs). Evidence: YES (measured in Runs 4, 5, 6, 7, 8 with specific examples). Generalizability: YES -- applies to any multi-stage pipeline where verification claims propagate. However, this is closely related to existing F9 (self-scoring/self-grading bias) and P11 (external artifacts over internal checklists). Rather than a new entry, this strengthens the evidence for F9 and P11. **Decision: Do not graduate as new entry. Update F9/P11 evidence in a future KB revision if warranted.**
+1. **False self-review verification / evidence-gating gap (5/8 runs pre-protocol, then Run 9 shows Corrector-1 inheritance gap)** -- Stability: YES (6 runs). Evidence: YES (measured rates). Generalizability: YES. However, this reinforces existing F9 (self-scoring bias) and P11 (external artifacts over internal checklists). The evidence-gating protocol is an application of P11, not a new pattern. **Decision: Do not graduate as new entry. Reinforces F9 + P11.**
 
-2. **Corrector-1 regression rate unresponsive to prompt changes (8 runs, mean 1.1)** -- Stability: YES. Evidence: YES. Generalizability: YES -- specific instance of F2. But again, this reinforces existing F2 rather than being a new pattern. **Decision: Do not graduate. Reinforces F2.**
+2. **Corrector-1 regression rate unresponsive to prompt changes (9 runs, mean 1.1)** -- Stability: YES. Evidence: YES. Generalizability: YES (instance of F2). Reinforces existing F2. **Decision: Do not graduate. Reinforces F2.**
 
-3. **Reader stage zero-value (8/8 runs)** -- Stability: YES. Evidence: YES (0 findings in 8 runs). Generalizability: PARTIAL -- applies to critique pipelines with documents under ~500 lines, not yet tested on longer documents. **Decision: Do not graduate. Negative result (stage adds no value) is operational, not a design principle.**
+3. **Reader stage zero-value (9/9 runs)** -- Stability: YES. Evidence: YES. Generalizability: PARTIAL (not tested on long docs). **Decision: Do not graduate. Operational decision, not a design principle.**
 
-4. **Researcher front-loading shifts CRITICAL distribution** -- Stability: PARTIAL (observed clearly in Run 8, suggestive in Runs 2 and 5). Evidence: YES. Generalizability: YES. **Decision: Hold for 1-2 more runs. Needs clearer isolation of the effect.**
+4. **Researcher front-loading shifts CRITICAL distribution (Run 8 clear, suggestive in Runs 2, 5, 9)** -- Stability: PARTIAL (4 suggestive data points, but Run 9 returned to 3 CRITICALs despite strong Researcher, weakening the pattern). Evidence: YES. **Decision: Hold. Run 9 provides counter-evidence -- CRITICAL count returned to 3 despite strong Researcher. The effect may be real but inconsistent.**
 
-**KB graduation result: No new entries this run.** All findings either reinforce existing patterns (F2, F9, P11) or need more data. Memory.md updated with date-stamped entries.
+5. **Corrector-2 zero-regression record (9/9 runs, increasingly complex judgment calls)** -- Stability: YES (9 runs). Evidence: YES (0 regressions, specific judgment examples per run). Generalizability: YES -- applies to any multi-stage pipeline where the final corrector operates on the most complete context. However, this may be a property of the stage's position (final, most context) rather than a generalizable design principle. **Decision: Hold for 1-2 more runs. If it holds at 12+ runs, consider graduating as "Final-stage correctors outperform mid-pipeline correctors" with position-based explanation.**
+
+**KB graduation result: No new entries this run.** All findings either reinforce existing patterns (F2, F9, P11) or need more data. This is the third consecutive run with no graduations -- the KB has stabilized at its current scope.
 
 ---
 
 ## Next Run Priorities
 
-1. **Drop the Reader stage entirely.** Eight runs of zero evaluative contribution. Fold any needed structured inventory into the Researcher prompt. Measure: does Researcher quality degrade without Reader input?
+1. **Drop the Reader stage.** Remove it from the pipeline configuration for Run 10. Nine runs of zero evaluative findings is conclusive. Monitor whether any downstream stage reports missing context (unlikely given Researcher's independent inventory).
 
-2. **Implement evidence-gated self-review for Corrector-1 and Drafter.** Replace "I verified X" with `VERIFIED: <evidence>` or `UNVERIFIED`. This is the single highest-impact change available -- it targets the pipeline's most dangerous failure mode (false verification, 5/8 runs) with Tier 2 enforcement (artifact requirement) instead of Tier 4 (prose instruction).
+2. **Extend evidence-gating to Corrector-1.** Add to Corrector-1 prompt: "Every factual claim you carry forward must have a VERIFIED: tag with your own evidence. Inherited Drafter tags are not valid for your output. If you cannot verify, mark UNVERIFIED: inherited." Track compliance rate in Run 10 effectiveness report.
 
-3. **Add regression count as a first-class metric in the effectiveness report template.** Track `corrector1_regressions` and `drafter_regressions` as numeric fields alongside application rate. This was recommended in the R2 retrospective and still not implemented.
+3. **Add citation verification requirement to Critic-2.** Add to Critic-2 prompt: "Before claiming a citation or reference is fabricated, you MUST read the cited file and report the specific line number where the entry should exist but does not. Claims of fabrication without file-read evidence are unsubstantiated." This addresses the new false-positive risk from Run 9.


### PR DESCRIPTION
## Summary
- Upgraded `/prd` slash command from 20-line stub to full interactive workflow with product-level thinking
- Integrated Garry Tan's gstack methodology: forcing questions (Demand Reality, Status Quo, Desperate Specificity, Narrowest Wedge), premise challenge, anti-sycophancy rules
- Added four scope modes from `/plan-ceo-review`: Expand, Selective Expand, Hold, Reduce
- Quality checklist with advisory validation (human is the real gate, per F2/F9 compliance data)
- Updated double-critique effectiveness and retrospective reports (Run 9)

Note: The `/prd` skill lives in `.claude/commands/prd.md` (gitignored). This PR contains only the tracked double-critique report updates. The skill is synced to ai-brain separately.

## Test plan
- [ ] Run `/prd` in Claude Code and verify the product diagnostic questions appear
- [ ] Verify scope mode selection works (Expand/Selective/Hold/Reduce)
- [ ] Verify PRD output follows document-guidelines 10-section template
- [ ] Verify escape hatch works when user says "skip the questions"

Generated with [Claude Code](https://claude.com/claude-code)