### PR TITLE
feat: NORMALIZE compliant-format detection + /prd skill conversion

### DIFF
--- a/src/__tests__/stages/normalize-stage.test.ts
+++ b/src/__tests__/stages/normalize-stage.test.ts
@@ -75,7 +75,73 @@ describe("normalize-stage", () => {
     await expect(runNormalizeStage(prdPath, dirs, config)).rejects.toThrow("Normalizer agent failed");
   });
 
+  it("adds COMPLIANT-FORMAT rule for document-guidelines PRDs", async () => {
+    const compliantPrd = `# My Project — PRD
+## 1. Problem Statement
+Something is broken.
+## 2. Objective
+Fix it.
+## 3. Requirements
+REQ-01: Do the thing.
+## 4. Non-Functional Requirements
+Fast.
+## 5. User Workflow
+User clicks button.
+## 6. Success Criteria
+It works.
+## 7. Out of Scope
+Everything else.
+## 8. Future Scope
+Later.
+## 9. Open Questions
+None.
+## 10. Evidence Base
+We checked.`;
+    writeFileSync(prdPath, compliantPrd);
+
+    const { runNormalizeStage } = await import("../../stages/normalize-stage.js");
+    await runNormalizeStage(prdPath, dirs, config);
+
+    const [agentConfig] = mockSpawn.mock.calls[0];
+    expect(agentConfig.rules.some((r: string) => r.includes("COMPLIANT-FORMAT"))).toBe(true);
+  });
+
+  it("does not add COMPLIANT-FORMAT rule for raw unstructured PRDs", async () => {
+    writeFileSync(prdPath, "# My Idea\nI want to build a thing that does stuff.");
+
+    const { runNormalizeStage } = await import("../../stages/normalize-stage.js");
+    await runNormalizeStage(prdPath, dirs, config);
+
+    const [agentConfig] = mockSpawn.mock.calls[0];
+    expect(agentConfig.rules.some((r: string) => r.includes("COMPLIANT-FORMAT"))).toBe(false);
+  });
+
   afterAll(() => {
     rmSync(testDir, { recursive: true, force: true });
+  });
+});
+
+describe("detectCompliantFormat", () => {
+  it("returns true for PRD with all required sections and REQ-IDs", async () => {
+    const { detectCompliantFormat } = await import("../../stages/normalize-stage.js");
+    const prd = `## 1. Problem Statement\n## 2. Objective\n## 3. Requirements\nREQ-01: Do X\n## 6. Success Criteria\n## 7. Out of Scope`;
+    expect(detectCompliantFormat(prd)).toBe(true);
+  });
+
+  it("returns false for raw unstructured text", async () => {
+    const { detectCompliantFormat } = await import("../../stages/normalize-stage.js");
+    expect(detectCompliantFormat("Just some notes about what I want to build")).toBe(false);
+  });
+
+  it("returns false when missing required sections", async () => {
+    const { detectCompliantFormat } = await import("../../stages/normalize-stage.js");
+    const prd = `## 1. Problem Statement\n## 3. Requirements\nREQ-01: Do X`;
+    expect(detectCompliantFormat(prd)).toBe(false);
+  });
+
+  it("returns false when sections present but no REQ-IDs", async () => {
+    const { detectCompliantFormat } = await import("../../stages/normalize-stage.js");
+    const prd = `## 1. Problem Statement\n## 2. Objective\n## 3. Requirements\nDo X\n## 6. Success Criteria\n## 7. Out of Scope`;
+    expect(detectCompliantFormat(prd)).toBe(false);
   });
 });

--- a/src/stages/normalize-stage.ts
+++ b/src/stages/normalize-stage.ts
@@ -8,6 +8,24 @@ import { loadConstitution } from "../config/loader.js";
 import type { HiveMindConfig } from "../config/schema.js";
 import type { PipelineDirs } from "../types/pipeline-dirs.js";
 
+/**
+ * Detect if a PRD already follows the document-guidelines 10-section format.
+ * Checks for 5 distinctive section headers plus REQ-ID numbering.
+ * False positives are low-cost (additive mode still injects memory/constitution).
+ */
+export function detectCompliantFormat(prdContent: string): boolean {
+  const requiredSections = [
+    /^##?\s+1\.\s+Problem Statement/im,
+    /^##?\s+2\.\s+Objective/im,
+    /^##?\s+3\.\s+Requirements/im,
+    /^##?\s+6\.\s+Success Criteria/im,
+    /^##?\s+7\.\s+Out of Scope/im,
+  ];
+  const hasAllSections = requiredSections.every((re) => re.test(prdContent));
+  const hasReqIds = /REQ-\d{2,}/.test(prdContent);
+  return hasAllSections && hasReqIds;
+}
+
 export async function runNormalizeStage(
   prdPath: string,
   dirs: PipelineDirs,
@@ -27,6 +45,11 @@ export async function runNormalizeStage(
     ? `FEEDBACK FROM REVIEWER: ${feedback}. Address this feedback in your output.`
     : "";
 
+  const isCompliant = detectCompliantFormat(prdContent);
+  const complianceRule = isCompliant
+    ? "COMPLIANT-FORMAT: This PRD already follows document-guidelines format with numbered sections and REQ-IDs. PRESERVE all existing sections, headings, and content verbatim. Do NOT restructure into the 7-section format. Only ADD: (1) memory/constitution references as inline notes within relevant sections, (2) any missing testable success criteria derived from requirements. Do not rename, reorder, merge, or remove any existing section."
+    : "";
+
   const result = await spawnAgentWithRetry(
     {
       type: "normalizer",
@@ -36,6 +59,7 @@ export async function runNormalizeStage(
       rules: [
         ...getAgentRules("normalizer"),
         ...(feedbackRule ? [feedbackRule] : []),
+        ...(complianceRule ? [complianceRule] : []),
       ],
       memoryContent,
       constitutionContent,


### PR DESCRIPTION
## Summary
- Convert `/prd` from `.claude/commands/prd.md` to a proper skill at `.claude/skills/prd/` with progressive disclosure (SKILL.md + 5 reference files)
- Add `detectCompliantFormat()` to normalize-stage.ts — detects PRDs following document-guidelines 10-section format
- Pass COMPLIANT-FORMAT rule to normalizer agent to preserve structure for well-structured PRDs (closes Gap 2)
- 4 new tests for detection function + 2 integration tests for rule injection

Note: The skill files live in `.claude/skills/prd/` (gitignored). This PR contains the TypeScript NORMALIZE changes only.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/stages/normalize-stage.test.ts` — 10/10 pass
- [x] `npm run build` passes
- [ ] AC-1: PRD with 10 sections + REQ-IDs → detectCompliantFormat returns true
- [ ] AC-2: Raw text → returns false
- [ ] AC-3: Partial sections → returns false
- [ ] AC-4: No REQ-IDs → returns false

Generated with [Claude Code](https://claude.com/claude-code)