### PR TITLE
fix: add missing updateLiveReport calls in feedback re-run paths

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -298,6 +298,7 @@ export async function resumeFromCheckpoint(
           feedback: null,
         });
 
+        if (config.liveReport) updateLiveReport(dirs.workingDir, "NORMALIZE", "Re-run with feedback complete, awaiting approval");
         console.log("NORMALIZE stage updated. Review again.");
         console.log(getCheckpointMessage("approve-normalize"));
         notifyCheckpoint(silent);
@@ -328,6 +329,7 @@ export async function resumeFromCheckpoint(
           timestamp: isoTimestamp(),
           feedback: null,
         });
+        if (config.liveReport) updateLiveReport(dirs.workingDir, "SPEC", "Re-run with feedback complete, awaiting approval");
         console.log("SPEC stage updated with feedback. Review again.");
         notifyCheckpoint(silent);
         return;


### PR DESCRIPTION
## Summary
- The NORMALIZE and SPEC feedback re-run paths in `resumeFromCheckpoint()` were missing `updateLiveReport()` calls
- This caused the live progress dashboard to not update when a stage was re-run with user feedback
- Added the standard `if (config.liveReport) updateLiveReport(...)` pattern to both paths, matching the 16+ existing call sites

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (554/554)
- [x] Grep confirms `updateLiveReport` present in both feedback blocks

Generated with [Claude Code](https://claude.com/claude-code)