### PR TITLE
fix: unify break to return in NORMALIZE feedback path

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -302,7 +302,7 @@ export async function resumeFromCheckpoint(
         console.log("NORMALIZE stage updated. Review again.");
         console.log(getCheckpointMessage("approve-normalize"));
         notifyCheckpoint(silent);
-        break;
+        return;
       }
 
       // Approved — proceed to SPEC with normalized PRD


### PR DESCRIPTION
Closes #73

Auto-fix by /housekeep Stage 4.

Changes `break` to `return` in the NORMALIZE feedback re-run path to match the SPEC feedback path, which already uses `return`. Both are functionally correct but `return` is more explicit about exiting the function.