### PR TITLE
fix: keep dashboard alive across checkpoint pauses

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -9,7 +9,7 @@ const POLL_INTERVAL_MS = 2000;
 const PAGE_SIZE = 200;
 const REQUEST_TIMEOUT_MS = 5000;
 
-interface DashboardHandle {
+export interface DashboardHandle {
   stop: () => void;
   url: string;
   signalShutdown: (shutdownAt: number) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { HiveMindError } from "./utils/errors.js";
 import { join } from "node:path";
 import { realpathSync } from "node:fs";
 import { approveCheckpoint, rejectCheckpoint } from "./state/checkpoint-ops.js";
+import { startDashboard } from "./dashboard/server.js";
+import type { DashboardHandle } from "./dashboard/server.js";
 
 export type ParsedCommand =
   | { command: "start"; prdPath: string; silent?: boolean; budget?: number; skipBaseline?: boolean; stopAfterPlan?: boolean; skipNormalize?: boolean; greenfield?: boolean; noDashboard?: boolean }
@@ -114,6 +116,19 @@ export async function main(): Promise<void> {
   const config = loadConfig(process.cwd());
   const dirs = resolvePipelineDirs(config, process.cwd());
 
+  // Start dashboard for commands that run pipeline stages
+  const dashboardCommands = new Set(["start", "approve", "reject", "resume", "retry"]);
+  const wantsDashboard = dashboardCommands.has(parsed.command) && !("noDashboard" in parsed && parsed.noDashboard);
+  let dashboardHandle: DashboardHandle | null = null;
+  if (wantsDashboard) {
+    try {
+      dashboardHandle = await startDashboard(dirs, config);
+    } catch (err) {
+      process.stderr.write(`Dashboard: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+
+  try {
   switch (parsed.command) {
     case "help": {
       printHelp();
@@ -134,7 +149,7 @@ export async function main(): Promise<void> {
       if (claudeCheck.exitCode !== 0) {
         throw new HiveMindError("claude CLI not found on PATH");
       }
-      await runPipeline(parsed.prdPath, dirs, config, { silent: parsed.silent, budget: parsed.budget, skipBaseline: parsed.skipBaseline, stopAfterPlan: parsed.stopAfterPlan, skipNormalize: parsed.skipNormalize, greenfield: parsed.greenfield, noDashboard: parsed.noDashboard });
+      await runPipeline(parsed.prdPath, dirs, config, { silent: parsed.silent, budget: parsed.budget, skipBaseline: parsed.skipBaseline, stopAfterPlan: parsed.stopAfterPlan, skipNormalize: parsed.skipNormalize, greenfield: parsed.greenfield, noDashboard: true });
       break;
     }
     case "bug": {
@@ -284,6 +299,12 @@ export async function main(): Promise<void> {
       await runExecuteStage(dirs, config);
       await runReportStage(dirs, config);
       break;
+    }
+  }
+  } finally {
+    if (dashboardHandle) {
+      dashboardHandle.signalShutdown(Date.now() + 60_000);
+      setTimeout(() => dashboardHandle!.stop(), 60_000);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Dashboard server was started inside `runPipeline()` and killed in its `finally` block at every checkpoint pause
- `hive-mind approve` never started a dashboard at all
- **Fix**: Move dashboard lifecycle to `main()` in `index.ts` — started before command switch, stopped in finally block
- Dashboard now survives checkpoint pauses and is available during approve/reject/resume/retry

## Changes
- `src/dashboard/server.ts`: Export `DashboardHandle` interface
- `src/index.ts`: Start dashboard in `main()` for pipeline commands, pass `noDashboard: true` to `runPipeline()`

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 647/647 passed
- [ ] Manual: start pipeline, hit checkpoint, verify `curl http://localhost:4040` returns 200
- [ ] Manual: run `hive-mind approve`, verify dashboard is accessible

Generated with [Claude Code](https://claude.com/claude-code)