### PR TITLE
fix: keep dashboard alive when pipeline pauses at checkpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,8 +303,13 @@ export async function main(): Promise<void> {
   }
   } finally {
     if (dashboardHandle) {
-      dashboardHandle.signalShutdown(Date.now() + 60_000);
-      setTimeout(() => dashboardHandle!.stop(), 60_000);
+      // If pipeline is paused at checkpoint, keep dashboard alive — its HTTP server
+      // keeps the event loop running so the process stays up until next command.
+      const checkpointExists = fileExists(join(dirs.workingDir, ".checkpoint"));
+      if (!checkpointExists) {
+        dashboardHandle.signalShutdown(Date.now() + 60_000);
+        setTimeout(() => dashboardHandle!.stop(), 60_000);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- v0.13.1 moved dashboard to `main()` but the `finally` block still unconditionally shut it down
- When pipeline pauses at checkpoint, `main()` returns → `finally` kills server → process exits
- **Fix**: Check `.checkpoint` file in `finally` — if exists (pipeline paused), skip shutdown. HTTP server keeps event loop alive.

## Changes
- `src/index.ts`: 4-line change in finally block — conditional dashboard shutdown

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 647/647 passed
- [ ] Manual: start pipeline, hit checkpoint, verify `curl http://localhost:4040` returns 200

Generated with [Claude Code](https://claude.com/claude-code)