### PR TITLE
fix: guard against negative elapsed time in swarm activity

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1436,7 +1436,7 @@ function renderActiveAgents(agents) {
   html += '<div class="swarm-rows">';
   for (var i = 0; i < agents.length; i++) {
     var a = agents[i];
-    var elapsed = now - (a.startTs || now);
+    var elapsed = Math.max(0, now - (a.startTs || now));
     var rowClass = a.pipeline ? 'swarm-row pipeline-agent' : 'swarm-row';
     html += '<div class="' + rowClass + '">';
     html += '<span class="swarm-hex"></span>';


### PR DESCRIPTION
Closes #92

Auto-fix by /housekeep Stage 4.

Added Math.max(0, ...) guard around elapsed time computation in renderActiveAgents to prevent negative values under clock skew.