### PR TITLE
fix: guard against NaN in checkpoint banner elapsed time

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1457,7 +1457,8 @@ function renderActiveAgents(agents) {
 
 function renderCheckpointBanner(checkpoint) {
   if (!checkpoint || !checkpoint.awaiting) return '';
-  var elapsed = Date.now() - new Date(checkpoint.timestamp).getTime();
+  var tsMs = checkpoint.timestamp ? new Date(checkpoint.timestamp).getTime() : NaN;
+  var elapsed = isNaN(tsMs) ? 0 : Date.now() - tsMs;
   var agoLabel = formatDuration(elapsed) + ' ago';
   var cmd = 'hive-mind approve';
   if (checkpoint.awaiting === 'ship') cmd = 'hive-mind approve  (ships to git)';


### PR DESCRIPTION
Closes #97

Auto-fix by /housekeep Stage 4.

Added NaN guard in renderCheckpointBanner: if checkpoint.timestamp is undefined/invalid, elapsed defaults to 0 instead of NaN.