### PR TITLE
fix: deriveActiveAgents returns structured object

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1422,14 +1422,14 @@ function deriveActiveAgents(stories, managerLog, costLog) {
       agents.push({ type: agentType, context: story.id, substage: substage, startTs: startTs, pipeline: false, wave: story.wave || currentWave });
     }
   }
-  agents.currentWave = currentWave;
-  return agents;
+  return { agents: agents, currentWave: currentWave };
 }
 
-function renderActiveAgents(agents) {
-  if (!agents || agents.length === 0) return '';
+function renderActiveAgents(result) {
+  if (!result || !result.agents || result.agents.length === 0) return '';
+  var agents = result.agents;
   var now = Date.now();
-  var waveHtml = agents.currentWave != null ? '<span class="swarm-wave">Wave ' + agents.currentWave + '</span>' : '';
+  var waveHtml = result.currentWave != null ? '<span class="swarm-wave">Wave ' + result.currentWave + '</span>' : '';
 
   var html = '<div class="swarm-card">';
   html += '<div class="swarm-header"><div class="swarm-title"><span class="swarm-pulse"></span> Swarm Activity</div>' + waveHtml + '</div>';


### PR DESCRIPTION
Closes #91

Auto-fix by /housekeep Stage 4.

Changed deriveActiveAgents to return { agents, currentWave } instead of an array with a .currentWave property. Updated renderActiveAgents to destructure the result.