### PR TITLE
docs: update README to reflect v0.16.0 capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,29 +33,41 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)
 ![Node](https://img.shields.io/badge/Node.js-18%2B-green)
 
-PRD-driven orchestrator that turns a product requirements document into working code through a multi-stage AI pipeline with human checkpoints.
+PRD-driven orchestrator that turns a product requirements document into working code through a multi-stage AI pipeline with human checkpoints, a real-time browser dashboard, and a dedicated bug-fix pipeline.
 
-> **Design iteration 3** — ground-up redesign following two earlier prototypes. Semver tracks the public release lifecycle starting at `v0.1.0`.
+> **Design iteration 3** -- ground-up redesign following two earlier prototypes. Currently at `v0.16.0`.
 
 ```
-PRD  -->  SPEC  -->  PLAN  -->  EXECUTE  -->  REPORT
-              [ human approval between each stage ]
+Start pipeline:
+
+PRD --> NORMALIZE --> BASELINE --> SPEC --> PLAN --> EXECUTE --> REPORT
+                  [ human approval at each checkpoint ]    [ scorecard ]
+
+Bug-fix pipeline:
+
+REPORT --> DIAGNOSE --> FIX --> VERIFY
 ```
 
 ## Features
 
-- **PRD-to-code pipeline** — Feed in a product requirements doc, get working code out
-- **Multi-stage AI agents** — Specialized agents for spec generation, planning, execution, and reporting
-- **Human-in-the-loop** — Approve, reject with feedback, or abort at every checkpoint
-- **Session continuity** — Resume interrupted pipelines without losing progress
-- **Learning system** — Agents capture and graduate learnings across runs
+- **PRD-to-code pipeline** -- Feed in a product requirements doc, get working code out
+- **Multi-stage AI agents** -- Specialized agents for spec generation, planning, execution, and reporting
+- **Human-in-the-loop** -- Approve, reject with feedback, or abort at every checkpoint
+- **Parallel wave execution** -- Stories fan out into concurrent waves of non-overlapping work with bounded concurrency; smart file-overlap detection defers conflicting stories to the next wave
+- **Live dashboard** -- Real-time browser UI with progress infographics and a swarm activity panel showing active parallel agents
+- **Codebase-aware spec** -- Four specialized agent types analyze existing code before generating specs
+- **Evidence-gating** -- SPEC pipeline validates claims with evidence, tracks regressions, and logs critiques
+- **Pipeline hardening** -- BUILD retry, pre-flight checks, early gates, and registry enforcement for reliable e2e execution
+- **Scorecard agent** -- Stage-aware report card that grades each pipeline phase
+- **Session continuity** -- Resume interrupted pipelines without losing progress
+- **Learning system** -- Agents capture and graduate learnings across runs
 
 ## Tech Stack
 
-- **TypeScript** (ESM) — Fully typed, npm-publishable CLI
-- **Claude API** via Claude Code CLI — Powers all AI agents
-- **Vitest** — Comprehensive test suite
-- **Zod** — Runtime config validation
+- **TypeScript** (ESM) -- Fully typed, npm-publishable CLI
+- **Claude API** via Claude Code CLI -- Powers all AI agents
+- **Vitest** -- Comprehensive test suite
+- **Zod** -- Runtime config validation
 
 ## Quick Start
 
@@ -72,6 +84,9 @@ npm i -g hive-mind
 # Start a pipeline
 hive-mind start --prd ./my-project.md
 
+# Start with a cost budget and stop after planning
+hive-mind start --prd ./my-project.md --budget 20 --stop-after-plan
+
 # Check status
 hive-mind status
 
@@ -80,28 +95,81 @@ hive-mind approve
 
 # Reject with feedback
 hive-mind reject --feedback "The spec is missing error handling requirements"
+
+# Resume an interrupted pipeline
+hive-mind resume
+
+# Retry a single failed story
+hive-mind retry S-003
+
+# Run bug-fix pipeline
+hive-mind bug --report ./bug-report.md
+
+# Generate project manifest
+hive-mind manifest
 ```
+
+## CLI Reference
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `start --prd <path>` | Run full pipeline (NORMALIZE -> SPEC -> PLAN -> EXECUTE -> REPORT) |
+| `bug --report <path>` | Run bug-fix pipeline (DIAGNOSE -> FIX -> VERIFY) |
+| `approve` | Approve current checkpoint and continue |
+| `reject --feedback <text>` | Reject with feedback and re-run current stage |
+| `resume` | Resume execution from saved plan |
+| `retry <storyId>` | Retry a failed story (reset + re-execute) |
+| `status` | Show current pipeline status |
+| `abort` | Cancel active pipeline |
+| `manifest` | Update MANIFEST.md in working directory |
+
+### Options
+
+| Flag | Scope | Description |
+|---|---|---|
+| `--silent` | all | Suppress desktop notifications |
+| `--budget <dollars>` | start | Set cost budget limit |
+| `--skip-baseline` | start, approve, bug | Skip pre-execution test baseline capture |
+| `--stop-after-plan` | start | Run SPEC + PLAN only, then exit |
+| `--skip-normalize` | start | Skip PRD normalize stage |
+| `--greenfield` | start | New project with no existing code |
+| `--no-dashboard` | start | Disable the real-time dashboard |
+| `--from <storyId>` | resume | Resume from specific story |
+| `--skip-failed` | resume | Skip failed stories on resume |
+| `--retry-failed` | resume | Reset failed stories and retry them |
+| `--clean` | retry | Delete report directory before retry |
 
 ## How It Works
 
-1. **SPEC** — An AI agent reads your PRD and generates a detailed technical specification
-2. **PLAN** — A planner agent breaks the spec into user stories with execution order
-3. **EXECUTE** — Each story goes through build, verify, commit, and learn sub-stages
-4. **REPORT** — A final report summarizes what was built, test results, and learnings
+1. **NORMALIZE** -- Detects PRD format compliance and normalizes `/prd`-generated documents into the expected structure (skippable with `--skip-normalize`)
+2. **BASELINE** -- Captures a test baseline from the existing codebase so regressions can be tracked (skippable with `--skip-baseline` or `--greenfield`)
+3. **SPEC** -- Codebase-aware agents read your PRD and existing code, then generate a detailed technical specification with evidence-gating and critique logs
+4. **PLAN** -- A planner agent breaks the spec into user stories with execution order; a plan-validator agent checks the result
+5. **EXECUTE** -- Stories fan out into parallel waves of non-overlapping work; each story goes through build (with retry), verify, compliance check, commit, and learn sub-stages
+6. **REPORT** -- A reporter agent summarizes what was built, test results, and learnings; a double-critique pass validates the report
+7. **SCORECARD** -- A scorecard agent grades each pipeline stage and produces a final report card
 
 Each stage pauses for human review before continuing to the next.
+
+A live browser dashboard (port 9100) shows real-time progress, infographics, and active agent swarm activity throughout the pipeline.
 
 ## Project Structure
 
 ```
 src/
-  stages/       # Pipeline stage implementations
-  agents/       # Agent spawner, prompts, model mapping
+  stages/       # Pipeline stages (normalize, baseline, spec, plan, execute, report, scorecard, diagnose)
+  agents/       # Agent spawner, prompts, model mapping, tool permissions
   state/        # Execution plan, checkpoints, logs
   config/       # Schema and loader
   memory/       # Learning system and graduation
   reports/      # Parser and templates
-  utils/        # File I/O, shell, token counting
+  dashboard/    # Live browser dashboard (server + launcher)
+  tooling/      # Project type detection and setup
+  types/        # TypeScript type definitions
+  manifest/     # MANIFEST.md generator
+  utils/        # File I/O, shell, token counting, cost tracking
   __tests__/    # Vitest test suite
 ```
 


### PR DESCRIPTION
## Summary
- Updated README to reflect all enhancements from v0.5.0 through v0.16.0
- Expanded pipeline diagram to show NORMALIZE, BASELINE, and SCORECARD stages plus bug-fix pipeline
- Added 6 new feature highlights: parallel wave execution, live dashboard, codebase-aware spec, evidence-gating, pipeline hardening, scorecard agent
- Added full CLI Reference section with commands and options tables
- Rewrote "How It Works" from 4 to 7 pipeline steps with dashboard and parallel execution notes
- Updated project structure with 4 new directories (dashboard, tooling, types, manifest)
- Replaced em dashes with double hyphens throughout

## Test plan
- [ ] Verify README renders correctly on GitHub (tables, code blocks, badges)
- [ ] Confirm all CLI commands and flags match `hive-mind help` output
- [ ] Run `npm run build` and `npm test` to ensure no breakage

https://claude.ai/code/session_01JuC4TVjBjDWjvcFn73owWH