### PR TITLE
fix: add paused visual state for checkpoint-gated stages

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -389,6 +389,9 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   .step.failed .step-hex { background: var(--red); }
   .step.failed .step-hex-inner { background: var(--red-light); color: var(--red); }
 
+  .step.paused .step-hex { background: transparent; border: 2px solid var(--amber); }
+  .step.paused .step-hex-inner { background: var(--amber-light); color: var(--amber); }
+
   .step-label {
     font-size: 13px;
     font-weight: 600;
@@ -1294,7 +1297,7 @@ function deriveStages(managerLog) {
       durationMs = endTs - startTs;
     } else if (startTs) {
       if (def.key === pausedStageKey) {
-        stageStatus = 'pending';
+        stageStatus = 'paused';
       } else {
         stageStatus = 'running';
         durationMs = Date.now() - startTs;
@@ -1521,7 +1524,7 @@ function renderStepper(stages, stories) {
   html += '<div class="stepper">';
   for (var s = 0; s < stages.length; s++) {
     var stage = stages[s];
-    var cls = stage.status === 'done' ? 'done' : (stage.status === 'running' ? 'running' : '');
+    var cls = stage.status === 'done' ? 'done' : (stage.status === 'running' ? 'running' : (stage.status === 'paused' ? 'paused' : ''));
     var inner = '';
     if (stage.status === 'done') {
       inner = '&#10003;';
@@ -1542,7 +1545,7 @@ function renderStepper(stages, stories) {
     if (s < stages.length - 1) {
       var connCls = '';
       if (stage.status === 'done' && stages[s + 1].status === 'done') connCls = 'done';
-      else if (stage.status === 'done' && stages[s + 1].status === 'running') connCls = 'active';
+      else if (stage.status === 'done' && (stages[s + 1].status === 'running' || stages[s + 1].status === 'paused')) connCls = 'active';
       html += '<div class="step-connector ' + connCls + '"></div>';
     }
   }


### PR DESCRIPTION
## Summary
- Dashboard stepper shows amber outline hex for checkpoint-gated stages instead of grey (pending)
- 3 touch points in server.ts: deriveStages status, renderStepper cls mapping, CSS class
- Connector between done and paused stages gets 'active' style

Closes #101

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] `.step.paused` CSS class exists with amber border styling
- [ ] `deriveStages` returns `'paused'` for gated stage (not `'pending'`)
- [ ] `renderStepper` maps `'paused'` to the CSS class

Generated with [Claude Code](https://claude.com/claude-code)