### PR TITLE
fix: generalize WAVE_START fallback into STAGE_DEFS with tests

### DIFF
--- a/src/__tests__/dashboard/derive-stages.test.ts
+++ b/src/__tests__/dashboard/derive-stages.test.ts
@@ -82,7 +82,7 @@ describe("deriveStages", () => {
     expect(stages[2].status).toBe("pending");
   });
 
-  it("returns paused status for checkpoint-gated stage", () => {
+  it("returns paused status for checkpoint-gated stage with startTs", () => {
     const input = makeInput({
       managerLog: [
         logEntry("PIPELINE_START", "2026-03-25T09:00:00Z"),
@@ -94,6 +94,29 @@ describe("deriveStages", () => {
     const stages = deriveStages(input, NOW);
     expect(stages[0].status).toBe("done"); // spec done
     expect(stages[1].status).toBe("paused"); // plan is gated by approve-spec
+  });
+
+  it("returns paused status for checkpoint-gated stage even without startTs", () => {
+    const input = makeInput({
+      managerLog: [
+        logEntry("PIPELINE_START", "2026-03-25T09:00:00Z"),
+      ],
+      checkpoint: { awaiting: "approve-normalize" },
+    });
+    const stages = deriveStages(input, NOW);
+    // spec is gated by approve-normalize; SPEC_START not in log, PIPELINE_START is fallback
+    // so spec has startTs via fallback -- but let's test with no fallback either
+    expect(stages[0].status).toBe("paused");
+  });
+
+  it("returns paused when gated stage has zero log entries for its start", () => {
+    const input = makeInput({
+      managerLog: [],
+      checkpoint: { awaiting: "approve-plan" },
+    });
+    const stages = deriveStages(input, NOW);
+    // execute is gated by approve-plan, but no log entries at all
+    expect(stages[2].status).toBe("paused");
   });
 
   it("marks stage as done when start and end actions both present", () => {

--- a/src/dashboard/derive-stages.ts
+++ b/src/dashboard/derive-stages.ts
@@ -155,6 +155,8 @@ export function deriveStages(input: DeriveStagesInput, now?: number): DerivedSta
         stageStatus = "running";
         durationMs = currentTime - startTs;
       }
+    } else if (def.key === pausedStageKey) {
+      stageStatus = "paused";
     }
 
     stages.push({ key: def.key, label: def.label, status: stageStatus, durationMs });

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1296,11 +1296,13 @@ function deriveStages(managerLog) {
       durationMs = endTs - startTs;
     } else if (startTs) {
       if (def.key === pausedStageKey) {
-        stageStatus = 'pending';
+        stageStatus = 'paused';
       } else {
         stageStatus = 'running';
         durationMs = Date.now() - startTs;
       }
+    } else if (def.key === pausedStageKey) {
+      stageStatus = 'paused';
     }
 
     stages.push({


### PR DESCRIPTION
## Summary
- Add `secondaryFallback` field to STAGE_DEFS (execute stage uses `WAVE_START`)
- Replace hard-coded `def.key === 'execute'` start-resolution with generic `firstOccurrence` lookup
- Extract `deriveStages` as typed module (`src/dashboard/derive-stages.ts`) for testability
- Add 11 unit tests in `src/__tests__/dashboard/derive-stages.test.ts`

Closes #104

## Test plan
- [ ] `npm run build` exits 0
- [ ] `npx vitest run src/__tests__/dashboard/derive-stages.test.ts` -- 11 tests pass
- [ ] No `def.key === 'execute'` in start-resolution logic (only in end-detection)
- [ ] `secondaryFallback: 'WAVE_START'` exists on execute stage def

Generated with [Claude Code](https://claude.com/claude-code)