### PR TITLE
fix: treat deleted source files as verification failure

### DIFF
--- a/src/stages/execute-verify.ts
+++ b/src/stages/execute-verify.ts
@@ -355,7 +355,10 @@ export function verifyFixApplied(
         if (existsSync(absPath)) return true;
       } else {
         // File existed before — check if content changed
-        if (!existsSync(absPath)) return true; // deleted = modification
+        if (!existsSync(absPath)) {
+          console.warn(`[K5 gate] Source file deleted: ${relPath} -- treating as failure`);
+          return false;
+        }
         const currentHash = createHash("sha256").update(readFileSync(absPath)).digest("hex");
         if (currentHash !== prevHash) return true;
       }


### PR DESCRIPTION
## Summary
- Fix K5 verification gate in `verifyFixApplied` so that a deleted source file (previously existing) is treated as a **failure** (`return false`) instead of a success (`return true`)
- Adds a `console.warn` log when this case is hit for debuggability
- Partial fix for #38 (item 3)

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] When a fixer deletes a source file that existed before, `verifyFixApplied` now returns `false`

Generated with [Claude Code](https://claude.com/claude-code)