### PR TITLE
refactor: bundle dashboard JS with esbuild to eliminate dual-copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-mind",
-  "version": "0.16.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-mind",
-      "version": "0.16.0",
+      "version": "0.17.1",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -16,6 +16,7 @@
         "@types/node": "^25.3.5",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
+        "esbuild": "^0.27.4",
         "eslint": "^10.0.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
@@ -25,9 +26,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
       "cpu": [
         "ppc64"
       ],
@@ -42,9 +43,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
       "cpu": [
         "arm"
       ],
@@ -59,9 +60,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
       "cpu": [
         "arm64"
       ],
@@ -76,9 +77,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +94,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
       "cpu": [
         "arm64"
       ],
@@ -110,9 +111,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +128,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
       "cpu": [
         "arm64"
       ],
@@ -144,9 +145,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
       "cpu": [
         "x64"
       ],
@@ -161,9 +162,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
       "cpu": [
         "arm"
       ],
@@ -178,9 +179,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
       "cpu": [
         "arm64"
       ],
@@ -195,9 +196,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
       "cpu": [
         "ia32"
       ],
@@ -212,9 +213,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
       "cpu": [
         "loong64"
       ],
@@ -229,9 +230,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
       "cpu": [
         "mips64el"
       ],
@@ -246,9 +247,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
       "cpu": [
         "ppc64"
       ],
@@ -263,9 +264,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
       "cpu": [
         "riscv64"
       ],
@@ -280,9 +281,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
       "cpu": [
         "s390x"
       ],
@@ -297,9 +298,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
       "cpu": [
         "x64"
       ],
@@ -314,9 +315,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
       "cpu": [
         "arm64"
       ],
@@ -331,9 +332,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +349,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
       "cpu": [
         "arm64"
       ],
@@ -365,9 +366,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
       "cpu": [
         "x64"
       ],
@@ -382,9 +383,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
       "cpu": [
         "arm64"
       ],
@@ -399,9 +400,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
       "cpu": [
         "x64"
       ],
@@ -416,9 +417,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
       "cpu": [
         "arm64"
       ],
@@ -433,9 +434,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
       "cpu": [
         "ia32"
       ],
@@ -450,9 +451,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
       "cpu": [
         "x64"
       ],
@@ -1500,9 +1501,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1513,32 +1514,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "hive-mind": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/build-dashboard.mjs",
+    "build:dashboard": "node scripts/build-dashboard.mjs",
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build-dashboard.mjs
+++ b/scripts/build-dashboard.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Bundles src/dashboard/dashboard-entry.ts into a browser-ready IIFE.
+ *
+ * Output: dist/dashboard/dashboard-bundle.js
+ * This file is read at runtime by server.ts and inlined into the HTML <script>.
+ */
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = join(__dirname, "..");
+
+await build({
+  entryPoints: [join(root, "src/dashboard/dashboard-entry.ts")],
+  bundle: true,
+  format: "iife",
+  target: "es2020",
+  outfile: join(root, "dist/dashboard/dashboard-bundle.js"),
+  // No minification — keeps the output readable for debugging.
+  minify: false,
+  // The entry assigns to globalThis, so we don't need a global name.
+  logLevel: "info",
+});

--- a/src/dashboard/dashboard-entry.ts
+++ b/src/dashboard/dashboard-entry.ts
@@ -1,0 +1,49 @@
+/**
+ * Browser entry point for dashboard bundle.
+ *
+ * esbuild bundles this into an IIFE that exposes the derive functions
+ * as globals, adapting the typed module signatures to the browser's
+ * global `state` variable.
+ */
+import { deriveStages as _deriveStages, STAGE_DEFS } from "./derive-stages.js";
+import type { DeriveStagesInput } from "./derive-stages.js";
+import { deriveActiveAgents as _deriveActiveAgents } from "./derive-agents.js";
+
+// The browser declares `var state` as a global — tell TS about it.
+declare const state: {
+  executionPlan?: { stories?: { status: string; id: string; substage?: string; subTasks?: { id: string; status: string }[]; wave?: number; durationMs?: number }[] } | null;
+  managerLog?: { action?: string; timestamp: string; storyId?: string | null; waveNumber?: number | null; storyIds?: string[]; attempt?: number; runId?: string }[];
+  costLog?: { storyId?: string; timestamp?: string; costUsd?: number; durationMs?: number }[];
+  checkpoint?: { awaiting?: string } | null;
+  shutdownAt?: number;
+} | null;
+
+/**
+ * Browser-compatible wrapper matching the inline signature:
+ *   deriveStages(managerLog) — reads stories/checkpoint/costLog from global `state`.
+ */
+function deriveStages(managerLog: DeriveStagesInput["managerLog"]) {
+  const stories = (state?.executionPlan?.stories) ?? null;
+  const checkpoint = state?.checkpoint ?? null;
+  const costLog = (state?.costLog as DeriveStagesInput["costLog"]) ?? null;
+  return _deriveStages({ managerLog, checkpoint, stories, costLog });
+}
+
+/**
+ * Browser-compatible wrapper matching the inline signature:
+ *   deriveActiveAgents(stories, managerLog, costLog)
+ */
+function deriveActiveAgents(
+  stories: Parameters<typeof _deriveActiveAgents>[0],
+  managerLog: Parameters<typeof _deriveActiveAgents>[1],
+  costLog: Parameters<typeof _deriveActiveAgents>[2],
+) {
+  return _deriveActiveAgents(stories, managerLog, costLog);
+}
+
+// Expose as globals for the rest of the inline <script> to use.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const w = globalThis as any;
+w.STAGE_DEFS = STAGE_DEFS;
+w.deriveStages = deriveStages;
+w.deriveActiveAgents = deriveActiveAgents;

--- a/src/dashboard/derive-agents.ts
+++ b/src/dashboard/derive-agents.ts
@@ -1,8 +1,8 @@
 /**
  * Extracted deriveActiveAgents logic for testability.
  *
- * NOTE: The inline browser JS in server.ts has an equivalent var-based copy.
- * Keep both in sync when modifying agent derivation logic.
+ * This is the single source of truth — esbuild bundles it into
+ * dashboard-bundle.js which server.ts inlines into the browser page.
  */
 
 export interface Story {

--- a/src/dashboard/derive-stages.ts
+++ b/src/dashboard/derive-stages.ts
@@ -1,8 +1,8 @@
 /**
  * Extracted deriveStages logic for testability.
  *
- * NOTE: The inline browser JS in server.ts has an equivalent var-based copy.
- * Keep both in sync when modifying stage derivation logic.
+ * This is the single source of truth — esbuild bundles it into
+ * dashboard-bundle.js which server.ts inlines into the browser page.
  */
 
 export interface StageDef {

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1,6 +1,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { join, resolve, sep } from "node:path";
+import { join, resolve, sep, dirname } from "node:path";
 import { readFile, readdir } from "node:fs/promises";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { PipelineDirs } from "../types/pipeline-dirs.js";
 import type { HiveMindConfig } from "../config/schema.js";
 import { openBrowser } from "./browser.js";
@@ -149,7 +151,29 @@ async function handleLogsRoute(
   sendJson(res, { lines: page, nextOffset });
 }
 
-const DASHBOARD_HTML = `<!DOCTYPE html>
+// Read the esbuild-generated dashboard bundle (derive-stages + derive-agents).
+// This is inlined into the <script> tag so the browser gets a single self-contained page.
+
+function resolveBundlePath(): string {
+  // When running from dist/ (production), the bundle is in the same directory.
+  const sameDir = join(dirname(fileURLToPath(import.meta.url)), "dashboard-bundle.js");
+  if (existsSync(sameDir)) return sameDir;
+  // When running from src/ (vitest/tsx), look in dist/dashboard/.
+  const fromSrc = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "dist", "dashboard", "dashboard-bundle.js");
+  return fromSrc;
+}
+
+let _dashboardHtml: string | null = null;
+function getDashboardHtml(): string {
+  if (!_dashboardHtml) {
+    const bundleJs = readFileSync(resolveBundlePath(), "utf-8");
+    _dashboardHtml = buildDashboardHtml(bundleJs);
+  }
+  return _dashboardHtml;
+}
+
+function buildDashboardHtml(bundleJs: string): string {
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -1162,6 +1186,9 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 <div class="toast-container" id="toastContainer"></div>
 
 <script>
+/* ===== BUNDLED: derive-stages + derive-agents (from esbuild) ===== */
+${bundleJs}
+
 /* ===== STATE ===== */
 var state = null;
 var pipelineStartTs = null;
@@ -1221,147 +1248,7 @@ function statusToCssStatus(status) {
 }
 
 /* ===== DERIVED DATA ===== */
-
-/* Pipeline stages derived from managerLog */
-var STAGE_DEFS = [
-  { key: 'spec',    label: 'Spec',    startAction: 'SPEC_START',    fallbackStart: 'PIPELINE_START', endAction: 'SPEC_COMPLETE', secondaryFallback: null },
-  { key: 'plan',    label: 'Plan',    startAction: 'PLAN_START',    fallbackStart: 'SPEC_COMPLETE',  endAction: 'PLAN_COMPLETE', secondaryFallback: null },
-  { key: 'execute', label: 'Execute', startAction: 'EXECUTE_START', fallbackStart: 'PLAN_COMPLETE',  endAction: 'EXECUTE_COMPLETE', secondaryFallback: 'WAVE_START' },
-  { key: 'report',  label: 'Report',  startAction: 'EXECUTE_COMPLETE', fallbackStart: null, endAction: 'REPORT_COMPLETE', secondaryFallback: null }
-];
-
-function deriveStages(managerLog) {
-  /* Scan the ENTIRE log and keep the LAST timestamp for each action type */
-  var actionTimestamps = {};
-  for (var i = 0; i < managerLog.length; i++) {
-    var entry = managerLog[i];
-    if (entry && entry.action) {
-      actionTimestamps[entry.action] = new Date(entry.timestamp).getTime();
-    }
-  }
-
-  /* Check if any managerLog action contains REPORT (case-insensitive) */
-  var hasReportAction = false;
-  var lastLogTs = null;
-  for (var r = 0; r < managerLog.length; r++) {
-    var act = managerLog[r].action || '';
-    if (act.toUpperCase().indexOf('REPORT') !== -1) {
-      hasReportAction = true;
-      var ts = new Date(managerLog[r].timestamp).getTime();
-      if (!lastLogTs || ts > lastLogTs) lastLogTs = ts;
-    }
-  }
-
-  /* Check story completion for EXECUTE stage */
-  var stories = (state && state.executionPlan && state.executionPlan.stories) ? state.executionPlan.stories : null;
-  var allStoriesDone = false;
-  var hasFailed = false;
-  if (stories && stories.length > 0) {
-    allStoriesDone = true;
-    for (var j = 0; j < stories.length; j++) {
-      if (stories[j].status === 'failed') hasFailed = true;
-      if (stories[j].status !== 'passed' && stories[j].status !== 'failed') allStoriesDone = false;
-    }
-  }
-
-  /* Find latest WAVE_COMPLETE or cost log timestamp as execute end proxy */
-  var executeEndTs = null;
-  for (var w = 0; w < managerLog.length; w++) {
-    var wAct = managerLog[w].action || '';
-    if (wAct.indexOf('WAVE_COMPLETE') !== -1) {
-      var wTs = new Date(managerLog[w].timestamp).getTime();
-      if (!executeEndTs || wTs > executeEndTs) executeEndTs = wTs;
-    }
-  }
-  if (!executeEndTs && allStoriesDone && state && state.costLog && state.costLog.length > 0) {
-    for (var c = 0; c < state.costLog.length; c++) {
-      var cTs = new Date(state.costLog[c].timestamp).getTime();
-      if (!executeEndTs || cTs > executeEndTs) executeEndTs = cTs;
-    }
-  }
-
-  /* Map checkpoint to the stage it gates (the NEXT stage that hasn't started yet) */
-  var checkpoint = state ? state.checkpoint : null;
-  var pausedStageKey = null;
-  if (checkpoint && checkpoint.awaiting) {
-    var cpToStage = {
-      'approve-normalize': 'spec',
-      'approve-spec': 'plan',
-      'approve-plan': 'execute',
-      'approve-preflight': 'execute',
-      'approve-integration': 'report',
-      'approve-diagnosis': 'execute'
-    };
-    pausedStageKey = cpToStage[checkpoint.awaiting] || null;
-  }
-
-  /* Find first occurrence of each secondaryFallback action */
-  var firstOccurrence = {};
-  for (var fw = 0; fw < managerLog.length; fw++) {
-    var fwAct = (managerLog[fw].action || '');
-    for (var d = 0; d < STAGE_DEFS.length; d++) {
-      if (STAGE_DEFS[d].secondaryFallback === fwAct && firstOccurrence[fwAct] == null) {
-        firstOccurrence[fwAct] = new Date(managerLog[fw].timestamp).getTime();
-      }
-    }
-  }
-
-  var stages = [];
-  for (var s = 0; s < STAGE_DEFS.length; s++) {
-    var def = STAGE_DEFS[s];
-    /* Resolve startTs: prefer _START action, then secondaryFallback first-occurrence, then fallback */
-    var startTs = actionTimestamps[def.startAction];
-    if (!startTs) {
-      if (def.secondaryFallback && firstOccurrence[def.secondaryFallback]) {
-        startTs = firstOccurrence[def.secondaryFallback];
-      } else if (def.fallbackStart) {
-        startTs = actionTimestamps[def.fallbackStart];
-      }
-    }
-    var endTs = actionTimestamps[def.endAction];
-    var stageStatus = 'pending';
-    var durationMs = null;
-
-    /* Special handling for EXECUTE: use story completion */
-    if (def.key === 'execute' && !endTs && startTs && allStoriesDone) {
-      stageStatus = hasFailed ? 'failed' : 'done';
-      durationMs = executeEndTs ? (executeEndTs - startTs) : (Date.now() - startTs);
-    /* Special handling for REPORT: check for any REPORT action in log */
-    } else if (def.key === 'report' && !endTs && hasReportAction) {
-      var reportStart = actionTimestamps[def.startAction] || (executeEndTs || actionTimestamps['PLAN_COMPLETE']);
-      if (reportStart) {
-        stageStatus = 'done';
-        durationMs = lastLogTs ? (lastLogTs - reportStart) : (Date.now() - reportStart);
-      }
-    } else if (endTs && startTs) {
-      stageStatus = 'done';
-      durationMs = endTs - startTs;
-    } else if (startTs) {
-      if (def.key === pausedStageKey) {
-        stageStatus = 'paused';
-      } else {
-        stageStatus = 'running';
-        durationMs = Date.now() - startTs;
-      }
-    } else if (def.key === pausedStageKey) {
-      stageStatus = 'paused';
-    }
-
-    stages.push({
-      key: def.key,
-      label: def.label,
-      status: stageStatus,
-      durationMs: durationMs
-    });
-  }
-
-  /* If execute is done but not failed, also check running state for execute */
-  if (stories && stages.length >= 3 && stages[2].status === 'running' && hasFailed) {
-    stages[2].status = 'failed';
-  }
-
-  return stages;
-}
+/* deriveStages + deriveActiveAgents are provided by the esbuild bundle above */
 
 function deriveCounts(stories) {
   var counts = { passed: 0, running: 0, failed: 0, pending: 0, blocked: 0 };
@@ -1392,98 +1279,6 @@ function deriveCostTotals(costLog) {
 }
 
 /* ===== SWARM ACTIVITY ===== */
-
-/* NOTE: derive-agents.ts has the typed, testable copy of this function.
-   Keep both in sync when modifying agent derivation logic. */
-function deriveActiveAgents(stories, managerLog, costLog) {
-  var agents = [];
-  var now = Date.now();
-  var currentWave = null;
-
-  var hasRunningStory = stories && stories.some(function(s) { return s.status === 'in-progress'; });
-  if (!hasRunningStory && managerLog.length > 0) {
-    var hasSpecComplete = false, hasPlanComplete = false, pipelineStartTs = null, specCompleteTs = null;
-    for (var i = 0; i < managerLog.length; i++) {
-      var entry = managerLog[i];
-      if (entry.action === 'PIPELINE_START') pipelineStartTs = new Date(entry.timestamp).getTime();
-      if (entry.action === 'SPEC_COMPLETE') { hasSpecComplete = true; specCompleteTs = new Date(entry.timestamp).getTime(); }
-      if (entry.action === 'PLAN_COMPLETE') hasPlanComplete = true;
-    }
-    if (pipelineStartTs && !hasSpecComplete) {
-      agents.push({ type: 'spec-agent', context: 'SPEC', substage: '', startTs: pipelineStartTs, pipeline: true, subtaskId: null, description: 'Generating specification from PRD' });
-    } else if (hasSpecComplete && !hasPlanComplete && specCompleteTs) {
-      agents.push({ type: 'planner', context: 'PLAN', substage: '', startTs: specCompleteTs, pipeline: true, subtaskId: null, description: 'Creating execution plan' });
-    }
-  }
-
-  if (stories) {
-    var latestActionByStory = {};
-    /* Build waveStartByStory from WAVE_START entries for immediate elapsed display */
-    var waveStartByStory = {};
-    for (var w = 0; w < managerLog.length; w++) {
-      var wEntry = managerLog[w];
-      if (wEntry.action === 'WAVE_START' && wEntry.waveNumber != null) currentWave = wEntry.waveNumber;
-      if (wEntry.storyId) latestActionByStory[wEntry.storyId] = wEntry;
-      if (wEntry.action === 'WAVE_START' && wEntry.storyIds) {
-        var wsTs = new Date(wEntry.timestamp).getTime();
-        var wsIds = wEntry.storyIds;
-        for (var wsi = 0; wsi < wsIds.length; wsi++) {
-          if (!waveStartByStory[wsIds[wsi]]) waveStartByStory[wsIds[wsi]] = wsTs;
-        }
-      }
-    }
-    var startTsByStory = {};
-    for (var cl = 0; cl < costLog.length; cl++) {
-      var ce = costLog[cl];
-      if (ce.storyId && ce.timestamp) {
-        var ts = new Date(ce.timestamp).getTime();
-        if (!startTsByStory[ce.storyId] || ts < startTsByStory[ce.storyId]) startTsByStory[ce.storyId] = ts;
-      }
-    }
-    for (var si = 0; si < stories.length; si++) {
-      var story = stories[si];
-      if (story.status !== 'in-progress') continue;
-      var substage = story.substage || 'BUILD';
-      var agentType = 'implementer';
-      if (substage === 'VERIFY') agentType = 'verifier';
-      else if (substage === 'COMMIT') agentType = 'committer';
-      else if (substage === 'TEST') agentType = 'tester';
-      var latestAction = latestActionByStory[story.id];
-      if (latestAction) {
-        if (latestAction.action === 'BUILD_COMPLETE') { agentType = 'refactorer'; substage = 'BUILD'; }
-        if (latestAction.action === 'VERIFY_ATTEMPT') { agentType = 'verifier'; substage = 'VERIFY'; }
-        if (latestAction.action === 'COMPLIANCE_CHECK') { agentType = 'compliance'; substage = 'VERIFY'; }
-        if (latestAction.action === 'BUILD_RETRY') { agentType = 'implementer'; substage = 'RETRY'; }
-      }
-      var subtaskId = null;
-      if (story.subTasks) {
-        for (var st = 0; st < story.subTasks.length; st++) {
-          if (story.subTasks[st].status === 'in-progress') { subtaskId = story.subTasks[st].id; break; }
-        }
-      }
-      var description = null;
-      if (latestAction) {
-        var act = latestAction.action;
-        var attemptSuffix = latestAction.attempt ? ' (attempt ' + latestAction.attempt + ')' : '';
-        if (act === 'BUILD_COMPLETE') description = 'Refactoring after build' + attemptSuffix;
-        else if (act === 'VERIFY_ATTEMPT') description = 'Running verification' + attemptSuffix;
-        else if (act === 'COMPLIANCE_CHECK') description = 'Running compliance checks';
-        else if (act === 'BUILD_RETRY') description = 'Retrying build' + attemptSuffix;
-        else if (act === 'FIX_UNVERIFIED') description = 'Fixing unverified items' + attemptSuffix;
-        else if (act === 'EVAL_ATTEMPT') description = 'Evaluating results' + attemptSuffix;
-        else description = 'Building implementation' + attemptSuffix;
-      } else {
-        if (substage === 'BUILD') description = 'Building implementation';
-        else if (substage === 'VERIFY') description = 'Running verification';
-        else if (substage === 'TEST') description = 'Running tests';
-        else if (substage === 'COMMIT') description = 'Preparing commit';
-      }
-      var startTs = startTsByStory[story.id] || waveStartByStory[story.id] || (now - (story.durationMs || 0));
-      agents.push({ type: agentType, context: story.id, substage: substage, startTs: startTs, pipeline: false, wave: story.wave ?? currentWave, subtaskId: subtaskId, description: description });
-    }
-  }
-  return { agents: agents, currentWave: currentWave };
-}
 
 function renderActiveAgents(result) {
   if (!result || !result.agents || result.agents.length === 0) return '';
@@ -2236,6 +2031,7 @@ elapsedTimerHandle = setInterval(updateElapsed, 1000);
 </body>
 </html>
 `;
+}
 
 export async function startDashboard(
   dirs: PipelineDirs,
@@ -2283,7 +2079,7 @@ export async function startDashboard(
 
     if (pathname === "/") {
       withTimeout(res, async () => {
-        sendHtml(res, DASHBOARD_HTML);
+        sendHtml(res, getDashboardHtml());
       });
       return;
     }


### PR DESCRIPTION
## Summary
- Replaces ~236 lines of manually-maintained inline JS in `server.ts` (duplicates of `deriveStages` and `deriveActiveAgents`) with an esbuild-generated IIFE bundle
- Adds `scripts/build-dashboard.mjs` that bundles `derive-stages.ts` + `derive-agents.ts` into `dist/dashboard/dashboard-bundle.js`
- Adds `src/dashboard/dashboard-entry.ts` as a thin browser adapter that imports the typed modules and exposes them as globals (adapting the typed function signatures to the browser's global `state` variable)
- Updates `server.ts` to read the bundle at startup and inject it into the HTML `<script>` tag
- Build pipeline: `tsc && node scripts/build-dashboard.mjs`

## Test plan
- [x] `npx tsc --noEmit` exits 0
- [x] `npm run build` exits 0
- [x] `dist/dashboard/dashboard-bundle.js` contains `deriveStages` and `deriveActiveAgents` globals
- [x] All 65 dashboard tests pass (`npx vitest run src/__tests__/dashboard/`)
- [x] Net reduction of 204 lines in server.ts (236 removed, 32 added)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)