### PR TITLE
docs: add harness roadmap release plan and R1 detailed plan

### DIFF
--- a/docs/harness-roadmap/roadmap-backlog.md
+++ b/docs/harness-roadmap/roadmap-backlog.md
@@ -1,0 +1,12 @@
+# Harness Roadmap -- Backlog
+
+Parking lot for new ideas that come up between releases. During release planning, pull items from here into the next release plan.
+
+## Format
+```
+- [Pillar X] One-line description -- source/context
+```
+
+## Backlog Items
+
+(Empty -- add new ideas here as they come up)

--- a/docs/harness-roadmap/roadmap-release-1.md
+++ b/docs/harness-roadmap/roadmap-release-1.md
@@ -1,0 +1,230 @@
+# Release 1: "Open the Pipes"
+
+**Theme:** Connect Hive Mind to the MCP ecosystem and grab low-hanging pipeline wins.
+**Timeline:** 2-3 weeks
+**Status:** Not started
+
+## Dependencies
+
+```
+Item 1 (MCP Phase 1) --> Items 2, 3 (WebSearch, Context7 need MCP)
+Items 4, 5, 6 have no dependencies (can start immediately)
+```
+
+**Recommended order:** Start items 4, 5, 6 in parallel with item 1. Items 2, 3 after item 1 lands.
+
+---
+
+## Stories
+
+### Story 1: MCP Phase 1 -- Consume MCP Servers
+
+**Goal:** Agents can use MCP servers declared in `.hivemindrc.json`.
+
+**Ref:** [Pillar 1 ss1.1](../roadmap-by-pillar.md) (lines 19-55)
+
+**What to build:**
+1. Add `mcpServers` field to config schema (`src/config/schema.ts`)
+2. In `spawnClaude()` (`src/utils/shell.ts`), if config has mcpServers, write a temp MCP config JSON and pass `--mcp-config <path>` to the Claude CLI invocation
+3. Add `defer_loading: true` support so tool schemas don't bloat context
+4. Add `.hivemindrc.json` example to README
+
+**Files to modify:**
+- `src/config/schema.ts` -- add mcpServers to Zod schema
+- `src/config/loader.ts` -- load mcpServers from config
+- `src/utils/shell.ts` -- pass --mcp-config flag to spawnClaude()
+- `README.md` -- document MCP config
+
+**ACs:**
+- `.hivemindrc.json` with `mcpServers` field is parsed without error
+- `spawnClaude()` passes `--mcp-config` to Claude CLI when mcpServers configured
+- Agents spawned with MCP config can use declared MCP tools
+- `defer_loading: true` prevents tool schemas from filling context
+- No behavioral change when mcpServers is absent (backwards compatible)
+
+**Effort:** Medium (2-3 days)
+
+---
+
+### Story 2: WebSearch/WebFetch for Research & Fixer Agents
+
+**Goal:** Research and fixer agents can search the web for docs, solutions, and API references.
+
+**Ref:** [Pillar 1 ss1.5](../roadmap-by-pillar.md) (lines 146-163)
+
+**What to build:**
+1. Add "WebSearch" and "WebFetch" to tool permission sets for research-capable agents
+2. Update agent tool permissions in `src/agents/tool-permissions.ts`
+
+**Files to modify:**
+- `src/agents/tool-permissions.ts` -- add WebSearch, WebFetch to RESEARCH_TOOLS and FIXER_TOOLS
+
+**ACs:**
+- Research agent (`researcher`) has WebSearch and WebFetch in allowed tools
+- Fixer agent (`fixer`, `compliance-fixer`) has WebSearch in allowed tools
+- Other agents (implementer, tester) do NOT get web tools
+- Existing tests pass (no regressions)
+
+**Effort:** Small (< 1 day)
+
+**Depends on:** Story 1 (WebSearch/WebFetch are built-in Claude tools, but MCP infra should land first for clean integration)
+
+---
+
+### Story 3: Context7 MCP for Live Library Docs
+
+**Goal:** Research and spec-drafter agents get current API docs instead of stale training data.
+
+**Ref:** [Pillar 1 ss1.4](../roadmap-by-pillar.md) (lines 119-142)
+
+**What to build:**
+1. Add Context7 as a default MCP server in bundled config (or document as recommended config)
+2. Update research agent prompt to mention Context7 tool availability
+3. Update spec-drafter prompt to use Context7 for framework/library decisions
+
+**Files to modify:**
+- Default `.hivemindrc.json` template or bundled config
+- `src/agents/prompts.ts` -- update researcher and spec-drafter prompts
+
+**ACs:**
+- Context7 MCP server starts when configured in `.hivemindrc.json`
+- Research agent prompt instructs: "Use Context7 to fetch current docs for any library/framework"
+- Spec-drafter prompt instructs: "Verify technology choices against current docs via Context7"
+
+**Effort:** Small (< 1 day)
+
+**Depends on:** Story 1 (needs MCP infra)
+
+---
+
+### Story 4: GAN Few-Shot Skepticism for Evaluators
+
+**Goal:** Critic and evaluator agents are trained to be harsh-but-fair via few-shot examples.
+
+**Ref:** [Pillar 3 ss3.4](../roadmap-by-pillar.md) (lines 507-516)
+
+**What to build:**
+1. Add 3-5 few-shot examples to critic agent prompts showing skeptical evaluation
+2. Examples should demonstrate: catching hidden issues, rejecting "looks good" surface quality, demanding evidence
+3. Add to spec-critic, code-reviewer, and compliance-reviewer prompts
+
+**Files to modify:**
+- `src/agents/prompts.ts` -- critic, code-reviewer, compliance-reviewer prompt sections
+
+**ACs:**
+- Spec-critic prompt includes at least 3 few-shot examples of skeptical critique
+- Code-reviewer prompt includes at least 2 few-shot examples
+- Examples demonstrate rejecting work that "looks fine" but has subtle issues
+- Existing tests pass
+
+**Effort:** Small (< 1 day)
+
+**Depends on:** Nothing (can start immediately)
+
+---
+
+### Story 5: Merge Compliance into VERIFY GAN Loop
+
+**Goal:** Eliminate the separate COMPLIANCE stage. Compliance criteria become additional ECs in the existing VERIFY loop.
+
+**Ref:** [Pillar 3 ss3.1](../roadmap-by-pillar.md) (lines 373-402)
+
+**What to build:**
+1. Update EC-generator prompt to include compliance criteria (instruction coverage) as additional ECs
+2. Remove compliance stage invocation from orchestrator
+3. Remove or deprecate `src/stages/execute-compliance.ts`
+4. Update execution plan types if compliance stage is referenced
+
+**Files to modify:**
+- `src/agents/prompts.ts` -- EC-generator prompt to include compliance ECs
+- `src/orchestrator.ts` -- remove compliance stage call
+- `src/stages/execute-compliance.ts` -- remove or mark deprecated
+- `src/types/` -- update if compliance stage enum/type exists
+
+**ACs:**
+- EC-generator produces compliance-related ECs (e.g., "all SPEC instructions have corresponding implementations")
+- VERIFY loop tests both functional ACs/ECs AND compliance ECs
+- No separate compliance stage runs
+- Pipeline produces same or better pass rates on test PRD
+- One fewer agent spawn per story (compliance-reviewer + compliance-fixer eliminated)
+
+**Effort:** Small-Medium (1-2 days)
+
+**Depends on:** Nothing (can start immediately)
+
+---
+
+### Story 6: Pipeline Timeout + Cost Velocity Alert
+
+**Goal:** Prevent runaway pipelines from running forever or burning budget.
+
+**Ref:** [Pillar 6 ss6.3](../roadmap-by-pillar.md) (lines 1603-1677)
+
+**What to build:**
+1. Add `pipelineTimeout` to config schema (default: 4 hours / 14,400,000ms)
+2. Add timeout check in orchestrator main loop -- abort if exceeded
+3. Add `checkCostVelocity()` function that projects total cost from progress
+4. Call cost velocity check after each story completes
+5. Warn (not abort) when projected cost exceeds 2x budget
+
+**Files to modify:**
+- `src/config/schema.ts` -- add pipelineTimeout field
+- `src/orchestrator.ts` -- add timeout check in main loop, add cost velocity check after each story
+- `src/utils/cost-tracker.ts` (or equivalent) -- add velocity projection function
+
+**ACs:**
+- Pipeline aborts with clear message after pipelineTimeout (default 4hr)
+- Cost velocity warning fires when projected total > 2x budget
+- Warning includes projected cost and recommendation to abort
+- Both are configurable via `.hivemindrc.json`
+- No impact when pipeline runs within normal bounds
+
+**Effort:** Small (1 day)
+
+**Depends on:** Nothing (can start immediately)
+
+---
+
+## Execution Plan
+
+```
+Week 1:
+  [parallel] Story 4 (few-shot skepticism) -- 0.5 day
+  [parallel] Story 5 (merge compliance)    -- 1-2 days
+  [parallel] Story 6 (timeout + velocity)  -- 1 day
+  [parallel] Story 1 (MCP Phase 1)         -- starts, takes 2-3 days
+
+Week 2:
+  Story 1 (MCP Phase 1)                    -- completes
+  Story 2 (WebSearch/WebFetch)             -- 0.5 day (after Story 1)
+  Story 3 (Context7)                       -- 0.5 day (after Story 1)
+  Integration testing + bug fixes          -- 1-2 days
+
+Week 3 (buffer):
+  Fix issues found in integration
+  Run full pipeline on test PRD
+  Compare scorecard against pre-R1 baseline
+```
+
+## Exit Criteria
+
+All must pass before R1 is considered done:
+
+- [ ] MCP Phase 1: agents use MCP servers from `.hivemindrc.json`
+- [ ] WebSearch: research agent searches web during SPEC research
+- [ ] Context7: research agent fetches live library docs
+- [ ] Few-shot skepticism: critic prompts include skeptical examples
+- [ ] Compliance merged: no separate compliance stage, criteria are ECs
+- [ ] Safeguards: pipeline aborts after timeout, warns on cost velocity
+- [ ] Regression: `npm run test` passes, `npm run build` succeeds
+- [ ] Validation: full pipeline run on test PRD produces scorecard >= baseline
+
+## Retrospective
+
+(To be filled after R1 completion)
+
+- What went well:
+- What was harder than expected:
+- What should change for R2:
+- New ideas discovered:
+- Items pulled from backlog:

--- a/docs/harness-roadmap/roadmap-releases.md
+++ b/docs/harness-roadmap/roadmap-releases.md
@@ -1,0 +1,132 @@
+# Hive Mind Harness Improvement -- Release Plan
+
+4 releases to evolve Hive Mind from a fixed pipeline to a self-improving, MCP-connected, visually-aware dark factory. Each release builds on the previous. New ideas go in `roadmap-backlog.md` and get pulled into the next release during planning.
+
+## Reference Docs
+- [Roadmap by Pillar](../roadmap-by-pillar.md) -- strategic view (active roadmap)
+- [Roadmap by Difference](../roadmap-by-difference.md) -- Anthropic comparison (research context)
+- [Raw Research](../harness-improvement-roadmap.md) -- 1920-line analysis
+- [Anthropic Comparison](../harness-comparison-anthropic.md) -- 8 key differences
+- [Pillar Definitions](../hive-mind-roadmap-v2.md) -- 6 strategic pillars
+
+---
+
+## Release 1: "Open the Pipes"
+
+**Theme:** Connect Hive Mind to the outside world and grab low-hanging fruit.
+
+**Timeline:** 2-3 weeks
+
+**What ships:**
+| # | Item | Pillar | Effort | Ref |
+|---|---|---|---|---|
+| 1 | MCP Phase 1 + deferred loading | P1 | Medium | P1 ss1.1, 1.6 |
+| 2 | WebSearch/WebFetch for agents | P1 | Small | P1 ss1.5 |
+| 3 | Context7 MCP for live docs | P1 | Small | P1 ss1.4 |
+| 4 | GAN few-shot skepticism (prompt change) | P3 | Small | P3 ss3.4 |
+| 5 | Merge compliance into VERIFY GAN loop | P3 | Small | P3 ss3.1 |
+| 6 | Pipeline timeout + cost velocity alert | P6 | Small | P6 ss6.3 |
+
+**Why first:** MCP unblocks everything. The rest are small/medium effort, high impact, zero architecture changes.
+
+**Exit criteria:**
+- Agents can use MCP servers declared in `.hivemindrc.json`
+- Research agent uses WebSearch and Context7
+- Compliance stage removed, criteria merged into VERIFY ECs
+- Critic prompts include few-shot skepticism examples
+- Pipeline aborts after 4hr timeout or 2x budget velocity
+
+**Detailed plan:** [roadmap-release-1.md](roadmap-release-1.md)
+
+---
+
+## Release 2: "Sharpen the Loop"
+
+**Theme:** Make the GAN loop cheaper, smarter, and safer.
+
+**Timeline:** 2-3 weeks (after R1)
+
+**Candidate items:**
+| # | Item | Pillar | Effort | Ref |
+|---|---|---|---|---|
+| 1 | Claude hooks exit code 2 for GAN feedback | P3 | Small | P3 ss3.5 |
+| 2 | Differential evaluation (only re-test failures) | P3 | Medium | P3 ss3.6 T3 |
+| 3 | Fail-fast evaluator (short-circuit) | P3 | Small | P3 ss3.6 T2 |
+| 4 | Dynamic stopping (score_delta check) | P3 | Small | P3 ss3.6 T6 |
+| 5 | Memory summarization between waves | P4 | Small | P4 ss4.1 |
+| 6 | Multi-dimensional scorecard with rubric | P3 | Medium | P3 ss3.3 |
+| 7 | Command blocklist + path-scoped writes | P6 | Small | P6 ss6.4 |
+
+**Why second:** Reduces cost per pipeline run by 30-50%. Quality improvements compound with every run after this.
+
+**Exit criteria:** (to be detailed when R1 nears completion)
+- VERIFY only re-tests failed ACs/ECs on retry
+- Hooks provide tsc/lint feedback during BUILD without separate agent
+- Scorecard grades 7 dimensions with weighted rubric
+- Memory.md summarized between waves
+
+---
+
+## Release 3: "Get Smarter"
+
+**Theme:** Make the harness learn from every run and see the UI.
+
+**Timeline:** 3-4 weeks (after R2)
+
+**Candidate items:**
+| # | Item | Pillar | Effort | Ref |
+|---|---|---|---|---|
+| 1 | LSP enablement for code intelligence | P1 | Medium | P1 ss1.3 |
+| 2 | Preview MCP for web project verification | P2 | Medium | P2 ss2.5 |
+| 3 | Claude-Mem integration (auto memory capture) | P4 | Medium | P4 ss4.6 |
+| 4 | SQL database for structured memory | P4 | Medium | P4 ss4.2 |
+| 5 | Skill-Creator SELF-IMPROVE stage | P4 | Large | P4 ss4.7 |
+| 6 | Context governance per agent type | P4 | Medium | P4 ss4.8 |
+| 7 | Surface graduation stats in REPORT | P4 | Small | P4 ss4.2 |
+
+**Why third:** Needs MCP (R1) and stable GAN loops (R2). The learning system is the path to a self-improving harness.
+
+**Exit criteria:** (stub -- detailed during R2)
+
+---
+
+## Release 4: "Scale Up"
+
+**Theme:** Shape the pipeline to the task and enable full autonomy.
+
+**Timeline:** 4-6 weeks (after R3)
+
+**Candidate items:**
+| # | Item | Pillar | Effort | Ref |
+|---|---|---|---|---|
+| 1 | Tiered modes (Quick/Standard/Thorough) | P5 | Medium | P5 ss5.5 |
+| 2 | Extract agents to .agent/ YAML definitions | P5 | Medium | P5 ss5.3 |
+| 3 | STRATEGIC-ONLY spec rule | P5 | Small | P5 ss5.1 |
+| 4 | Dark factory mode (--autonomous, holdout, quality gate) | P6 | Large | P6 ss6.1 |
+| 5 | Channels for mobile checkpoint approval | P6 | Medium | P6 ss6.7 |
+| 6 | Community skills per project type | P4 | Medium | P4 ss4.5 |
+| 7 | Figma MCP for design-aware pipeline | P2 | Large | P2 ss2.3 |
+| 8 | Adaptive concurrency based on rate limits | P6 | Medium | P6 ss6.2 |
+
+**Why last:** Largest changes, need the most testing, benefit from everything before them.
+
+**Exit criteria:** (stub -- detailed during R3)
+
+---
+
+## How to Use This Plan
+
+1. **Active release:** Only one release is actively being worked on at a time
+2. **New ideas:** Add to [roadmap-backlog.md](roadmap-backlog.md) with one-liner + pillar tag
+3. **Release planning:** When current release is ~75% done, detail the next release plan
+4. **Items can move:** If an R3 item becomes urgent, pull it into R2. If an R1 item is blocked, push to R2
+5. **Retrospective:** After each release, add a retro section to the release plan doc
+6. **Validation:** After each release, run a full pipeline on a test PRD and compare scorecard against baseline
+
+## Deferred (v2+)
+Items explicitly deferred beyond R4:
+- Full RAG + SQL memory with embeddings (P4)
+- MCP Phase 2: expose Hive Mind as MCP server (P1)
+- Docker container sandbox for dev agents (P6)
+- Staffing agent for fully dynamic pipeline (P5)
+- NotebookLLM-py integration (P6)


### PR DESCRIPTION
## Summary
- Creates `docs/harness-roadmap/` folder for implementation planning docs
- `roadmap-releases.md`: 4-release one-pager (R1: Open the Pipes, R2: Sharpen the Loop, R3: Get Smarter, R4: Scale Up)
- `roadmap-release-1.md`: detailed R1 plan with 6 stories, dependency graph, 3-week execution timeline, exit criteria
- `roadmap-backlog.md`: parking lot stub for new ideas between releases

## Test plan
- [ ] All 3 files exist in docs/harness-roadmap/
- [ ] Release plan references correct pillar doc sections
- [ ] R1 plan has ACs for all 6 stories