### PR TITLE
docs: add design principles to harness roadmap (skills-first, one-PR-per-story)

### DIFF
--- a/docs/harness-roadmap/roadmap-backlog.md
+++ b/docs/harness-roadmap/roadmap-backlog.md
@@ -9,4 +9,5 @@ Parking lot for new ideas that come up between releases. During release planning
 
 ## Backlog Items
 
-(Empty -- add new ideas here as they come up)
+- [P5] One PR per story in pipeline -- each story gets own branch/PR instead of one big branch (candidate for R2)
+- [P4] Evaluate which R2-R4 prompt-based items should be skills -- audit during R2 planning to ensure skill-creator can improve them in R3

--- a/docs/harness-roadmap/roadmap-release-1.md
+++ b/docs/harness-roadmap/roadmap-release-1.md
@@ -4,6 +4,22 @@
 **Timeline:** 2-3 weeks
 **Status:** Not started
 
+## Design Principles
+
+**1. Skills over hardcoded prompts.** Prompt-based items (few-shot examples, EC-generator rules, Context7 instructions) must be implemented as `.claude/skills/` files, not hardcoded in `prompts.ts`. Claude CLI auto-loads skills from the project's `.claude/skills/` directory via the `cwd` passed to `spawnClaude()`. This makes them editable without code changes and auto-improvable by skill-creator in R3.
+
+Applies to: Story 3 (Context7 instructions), Story 4 (few-shot skepticism), Story 5 (compliance EC rules).
+Does NOT apply to: Story 1 (MCP infra -- code), Story 2 (tool permissions -- code), Story 6 (timeout -- code).
+
+**2. One PR per story.** Each story = one PR. No multi-story PRs. This keeps PRs reviewable, revertable, and CI-testable independently. For large stories, break into sub-PRs:
+- Story 1 (MCP Phase 1) suggested sub-PRs:
+  - PR 1a: config schema + loader changes
+  - PR 1b: spawnClaude() MCP flag passing
+  - PR 1c: deferred loading support
+  - PR 1d: README docs
+
+---
+
 ## Dependencies
 
 ```

--- a/docs/harness-roadmap/roadmap-releases.md
+++ b/docs/harness-roadmap/roadmap-releases.md
@@ -117,11 +117,13 @@
 ## How to Use This Plan
 
 1. **Active release:** Only one release is actively being worked on at a time
-2. **New ideas:** Add to [roadmap-backlog.md](roadmap-backlog.md) with one-liner + pillar tag
-3. **Release planning:** When current release is ~75% done, detail the next release plan
-4. **Items can move:** If an R3 item becomes urgent, pull it into R2. If an R1 item is blocked, push to R2
-5. **Retrospective:** After each release, add a retro section to the release plan doc
-6. **Validation:** After each release, run a full pipeline on a test PRD and compare scorecard against baseline
+2. **One PR per story:** Each story = one PR. No multi-story PRs. Large stories get sub-PRs. Keeps reviews small and revertable.
+3. **Skills over hardcoded prompts:** Prompt-based items are `.claude/skills/` files, not hardcoded in `prompts.ts`. Auto-improvable by skill-creator in R3.
+4. **New ideas:** Add to [roadmap-backlog.md](roadmap-backlog.md) with one-liner + pillar tag
+5. **Release planning:** When current release is ~75% done, detail the next release plan
+6. **Items can move:** If an R3 item becomes urgent, pull it into R2. If an R1 item is blocked, push to R2
+7. **Retrospective:** After each release, add a retro section to the release plan doc
+8. **Validation:** After each release, run a full pipeline on a test PRD and compare scorecard against baseline
 
 ## Deferred (v2+)
 Items explicitly deferred beyond R4:


### PR DESCRIPTION
## Summary
- Adds Design Principles section to R1 plan: skills over hardcoded prompts, one PR per story
- Updates release plan How to Use section with PR and skills rules
- Adds 2 backlog items: one-PR-per-story pipeline feature (R2), skills audit (R2 planning)

## Test plan
- [ ] R1 plan has Design Principles section before Dependencies
- [ ] Release plan has rules 2 and 3 in How to Use section
- [ ] Backlog has 2 items