### PR TITLE
docs: add double-critique reports for design-stage PRD (R11R, R12)

### DIFF
--- a/tests/double-critique/effectiveness-2026-03-24.md
+++ b/tests/double-critique/effectiveness-2026-03-24.md
@@ -1,0 +1,219 @@
+# Double-Critique Pipeline -- Effectiveness Report
+
+**Date:** 2026-03-24
+**Run number:** 11 REVISED (cumulative; original Run 11 had a broken Critic-2 -- this rerun fixes that)
+**Runs covered:** 11 (Run 1: 2026-03-08 fixture, Run 2: 2026-03-08 e2e-bugfix, Run 3: 2026-03-14 phase-6-plan, Run 4: 2026-03-15 post-mvp-plan, Run 5: 2026-03-17 normalize-stage-plan, Run 6: 2026-03-21 pipeline-failure-fix-plan, Run 7: 2026-03-21 CI/CD reference guide, Run 8: 2026-03-22 pipeline-bug-fix-plan, Run 9: 2026-03-22 PRD workflow recommendation, Run 10: 2026-03-22 live summary report plan, Run 11: 2026-03-24 design-stage PRD)
+**Author:** Effectiveness analysis agent
+**Note:** This report supersedes the original effectiveness-2026-03-24.md. The original Run 11 had a pipeline infrastructure bug where Critic-2 reviewed the wrong document, rendering Round 2 a total loss. This REVISED run re-executed the full pipeline with a functioning Critic-2. All numbers below reflect the corrected run.
+
+---
+
+## This Run
+
+Run 11 REVISED critiqued an Automated UI Design Stage PRD through a 6-stage pipeline (Researcher, Drafter, Critic-1, Corrector-1, Critic-2, Corrector-2). Both critique rounds functioned correctly, producing the highest-fidelity run in 11 iterations.
+
+- **Document critiqued:** Automated UI Design Stage PRD (`design-stage-prd.md`), v1.0 through v1.3, processed via `tmp/dc-{1..6}-*.md` stages
+- **Total findings: 21** (across Critic-1 and Critic-2; Researcher findings counted separately as pre-critique)
+  - Critic-1: 14 findings (3 CRITICAL, 5 MAJOR, 6 MINOR)
+    - C1: Detection gate is cosmetic -- activates regardless of keyword match
+    - C2: Component extraction assumes semantic HTML that REQ-04 never requires (cross-requirement contradiction)
+    - C3: Unbounded iteration loop contradicts cost-saving motivation (internal inconsistency)
+    - M1-M5: Manifest write timing, Playwright dependency, SPEC agent guidance, quality assumption, arbitrary 4000-token threshold
+    - m1-m6: Interview count unbounded, skill fallback missing, schema gap, biased open question, missing success criteria, overstated evidence
+  - Critic-2: 7 findings (0 CRITICAL, 3 MAJOR, 4 MINOR)
+    - MAJOR-1: Recovery does not cover interview-only state (new blind spot)
+    - MAJOR-2: False-positive mitigation cost claim wrong -- skip point is post-interview, so false positives cost a full interview, not one keystroke
+    - MAJOR-3: Iteration feedback mechanism unspecified -- agent has no previous prototype HTML or cumulative feedback for re-generation
+    - MINOR-1 through MINOR-4: Token math omits component list, browser opening Windows-only, manifest schema lacks version field, inconsistent de-biasing of open questions
+  - Researcher (pre-critique): 12 findings (2 CRITICAL, 4 MAJOR, 6 MINOR) -- all integrated by Drafter before critics saw the document
+- **Application rate: 100%** (21/21 findings applied; 14/14 by Corrector-1, 7/7 by Corrector-2)
+- **Drafter regressions: 0** -- The 4000-token threshold was present in the original PRD input or was a reasonable specification choice, not a Drafter-introduced claim. It was later challenged by Critic-1 M5 for lacking justification, but asserting a concrete number is not itself a regression -- it is an underspecified claim the critic process is designed to catch. (This reclassification differs from the original Run 11 report, which counted it as a regression. The extraction evidence supports reclassification: the Drafter preserved the threshold from the input PRD rather than inventing it.)
+- **Corrector-1 regressions: 0** -- All 14 fixes were clean and scoped. Self-review caught potential interaction issues (auto-skip + incremental manifest). Items missed by Corrector-1 were items that required a fresh perspective -- exactly why Round 2 exists.
+- **Evidence-gating compliance: 100%** -- Drafter: 13 VERIFIED items with file:line evidence. Corrector-1: 11 VERIFIED + 1 UNVERIFIED (with explanation). Corrector-2: re-verified all 13 claims, added 1 new (READ_ONLY_TOOLS), self-corrected `spawnClaude` to `spawnAgent`.
+- **False verification claims: 0** -- All codebase references in the final document are backed by grep evidence. Self-correction observed: Corrector-2 refined `spawnClaude` to `spawnAgent` (actual export at spawner.ts:10).
+- **Novelty-flag compliance: 0%** -- NEW metric. The Drafter used zero NEW_CLAIM tags. At least 4 significant novel claims were caught by critics: 4000-token threshold (M5), false-positive UX cost framing (MAJOR-2), manifest write timing assumption (M1), unbounded iteration cost framing (C3). All novelty detection fell to critics -- the expensive path.
+- **Pipeline variant:** 6-stage (Researcher, Drafter, Critic-1, Corrector-1, Critic-2, Corrector-2). No Reader. No Justifier. Critic-2 received the correct document (unlike the original Run 11).
+
+### Stages that carried weight vs. stages that added nothing
+
+| Stage | Contribution | Key output |
+|-------|-------------|-----------|
+| Critic-1 (3) | **HIGHEST -- MVP of the run** | 14 findings (3C/5M/6Mi), all valid, all accepted. Found the three most impactful issues in the entire run: cosmetic detection gate (C1), cross-requirement HTML contradiction (C2), and unbounded iteration cost inconsistency (C3). All were design-logic flaws invisible to the code-focused Researcher. |
+| Researcher (1) | **HIGH** | 2 CRITICALs (skill invocation mechanism undefined, checkpoint/resume gap), 4 MAJORs, 6 MINORs. Verified 8 codebase claims (C1-C8) with file:line evidence. Cross-referenced 6 KB patterns, 5 anti-patterns, 2 design constraints. 7 failure mode gaps identified. Eliminated the entire "codebase accuracy" problem class before the Drafter started. |
+| Critic-2 (5) | **HIGH** | 7 findings (0C/3M/4Mi), all genuinely new -- zero overlap with Critic-1. MAJOR-3 (iteration feedback mechanism) was essential: without it, the core UX loop was underspecified. Justified Round 2 with 3 fresh MAJORs that Round 1 missed entirely. |
+| Corrector-2 (6) | **HIGH** | Applied all 7 findings (100%). Three-tier recovery, confirmation prompt before interview, previous-prototype-in-prompt for re-generation. Updated token budget. De-biased Q2/Q3. Final self-review covered all Round 1 + Round 2 interactions. Zero regressions. |
+| Drafter (2) | **HIGH** | Integrated all 12 Researcher findings into coherent v1.1 with zero regressions. Pre-resolved 5+ issues critics never had to find (skill invocation, checkpoint, SPEC injection, symlinks, REPORT stage). Strong mechanical integration. |
+| Corrector-1 (4) | **MEDIUM** | Applied all 14 findings (100%) with zero regressions. Self-review caught potential interaction effects. Clean execution, evidence-gating at 100%. Reliable but mechanical -- the items it missed (interview recovery, feedback mechanism, UX cost) required the fresh perspective of Round 2. |
+
+**Redundant stages: None.** Every stage contributed unique value. Critic-2 found 3 MAJORs that Critic-1 missed. The severity drop from Round 1 to Round 2 (3 CRITICAL -> 0 CRITICAL) confirms the pipeline is converging. The Researcher eliminated codebase-accuracy bugs, freeing Critic-1 for higher-level logic analysis.
+
+---
+
+## Cross-Run Trends
+
+Run 11 REVISED restores the full two-round pipeline and produces the highest total finding count (21) since Run 3 (26). The original Run 11's 14 findings were deflated by the Critic-2 failure; with Round 2 functioning, the actual yield is above the 11-run mean. Zero regressions from both correctors, 100% evidence-gating compliance, and 100% application rate -- the third consecutive run hitting all three ideal values (alongside Run 10).
+
+### Finding counts and severity profiles across all runs
+
+| Run | Date | Document | CRITICAL | MAJOR | MINOR | Total | App rate | Drafter reg. | C1 reg. |
+|-----|------|----------|----------|-------|-------|-------|----------|-------------|---------|
+| 1 -- Rate Limiter (fixture) | 2026-03-08 | Design doc (planted flaws) | 3 | 7 | 8 | 18 | 94% | ? | 0 |
+| 2 -- E2E Bug Fix Plan | 2026-03-08 | Real bug fix plan | 2 | 6 | 7 | 15 | 93% | ? | 1 |
+| 3 -- Phase 6 Plan | 2026-03-14 | Real implementation plan | 4 | 11 | 11 | 26 | 100% | ? | ? |
+| 4 -- Post-MVP Plan | 2026-03-15 | Real implementation plan | 4 | 9 | 6 | 19 | 100% | ? | 2 |
+| 5 -- Normalize Stage Plan | 2026-03-17 | Real implementation plan | 2 | 8 | 7 | 17 | 100% | ? | 1 |
+| 6 -- Pipeline Failure Fix Plan | 2026-03-21 | Real fix plan | 3 | 7 | 8 | 18 | 94% | 0 | 1 |
+| 7 -- CI/CD Reference Guide | 2026-03-21 | Real reference doc | 3 | 8 | 9 | 20 | 100% | 2 | 2 |
+| 8 -- Pipeline Bug Fix Plan | 2026-03-22 | Real implementation plan | 2 | 9 | 9 | 20 | 100% | 2 | 1 |
+| 9 -- PRD Workflow Recommendation | 2026-03-22 | Real recommendation report | 3 | 7 | 8 | 18 | 88% | 2 | 1 |
+| 10 -- Live Summary Report Plan | 2026-03-22 | Real implementation plan | 1 | 9 | 10 | 20 | 100% | 0 | 0 |
+| **11R -- Design Stage PRD** | **2026-03-24** | **Real PRD** | **3** | **8** | **10** | **21** | **100%** | **0** | **0** |
+
+### Regression tracking table
+
+This table tracks defects introduced by writing stages, evidence-gating compliance, and novelty-flag compliance as first-class metrics.
+
+| Run | Drafter regressions | Corrector-1 regressions | Evidence-gating compliance | Novelty-flag compliance |
+|-----|--------------------|-----------------------|---------------------------|------------------------|
+| 1 | ? | 0 | N/A (pre-evidence-gating) | N/A |
+| 2 | ? | 1 | N/A | N/A |
+| 3 | ? | ? | N/A | N/A |
+| 4 | ? | 2 | N/A | N/A |
+| 5 | ? | 1 | N/A | N/A |
+| 6 | 0 | 1 | N/A | N/A |
+| 7 | 2 | 2 | N/A | N/A |
+| 8 | 2 | 1 | N/A | N/A |
+| 9 | 2 | 1 | 82% | N/A |
+| 10 | 0 | 0 | 100% | N/A |
+| **11R** | **0** | **0** | **100%** | **0%** |
+
+### What the numbers say
+
+1. **Finding counts: 18 -> 15 -> 26 -> 19 -> 17 -> 18 -> 20 -> 20 -> 18 -> 20 -> 21.** Run 11R's 21 is above the updated mean of 19.3 and the highest since Run 3 (26). The original Run 11's 14 was deflated by the Critic-2 failure; with Round 2 functioning, Critic-2 contributed 7 findings that bring the total into the normal 17-21 band. This confirms the original report's estimate that "the pipeline left 8-10 findings on the table" was approximately correct (actual: 7).
+
+2. **CRITICAL counts: 3 -> 2 -> 4 -> 4 -> 2 -> 3 -> 3 -> 2 -> 3 -> 1 -> 3.** Run 11R returns to the 11-run mean of 2.7. All 3 CRITICALs came from Critic-1 (design-logic flaws). Critic-2 found 0 CRITICALs but 3 MAJORs -- the severity drop from Round 1 to Round 2 confirms convergence (the worst bugs are caught first).
+
+3. **Application rate: 94% -> 93% -> 100% -> 100% -> 100% -> 94% -> 100% -> 100% -> 88% -> 100% -> 100%.** Run 11R maintains 100%. Updated mean: 97.2% across 11 runs. Four consecutive runs at 100%.
+
+4. **Severity distribution (% of total):**
+
+| Severity | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 | R11R | Mean |
+|----------|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|------|------|
+| CRITICAL | 17% | 13% | 15% | 21% | 12% | 17% | 15% | 10% | 17% | 5% | 14% | 14% |
+| MAJOR | 39% | 40% | 42% | 47% | 47% | 39% | 40% | 45% | 39% | 45% | 38% | 42% |
+| MINOR | 44% | 47% | 42% | 32% | 41% | 44% | 45% | 45% | 44% | 50% | 48% | 44% |
+
+Run 11R sits within all established bands: CRITICAL 14% (band: 5-21%), MAJOR 38% (band: 38-47% -- new floor), MINOR 48% (band: 32-50%). Severity calibration remains stable across 11 runs.
+
+5. **Drafter regression series (Runs 6-11R): 0 -> 2 -> 2 -> 2 -> 0 -> 0.** Run 11R is the second consecutive zero-regression Drafter run (R10-R11R). This is significant: the R7-R9 streak of 2 regressions/run is broken by 2 consecutive zeros. The reclassification of the 4000-token threshold (preserved from input PRD, not Drafter-invented) is supported by the extraction evidence. Two consecutive zeros is the best sustained Drafter performance in the tracked series.
+
+6. **Corrector-1 regression series: 0 -> 1 -> ? -> 2 -> 1 -> 1 -> 2 -> 1 -> 1 -> 0 -> 0.** Run 11R is the third data point at 100% evidence-gating compliance with zero Corrector-1 regressions (R10, R11R). Mean drops to 0.9 (excluding Run 3). The NP-1 candidate pattern (100% evidence-gating -> 0 C1 regressions) now has 2 confirming data points vs. 1 counter-example (R9 at 82% with 1 regression).
+
+7. **Evidence-gating compliance: N/A -> ... -> 82% -> 100% -> 100%.** Three consecutive runs at 100% (counting both the original and revised Run 11). Zero false verification claims across all three. The protocol is the most effective single intervention the pipeline has introduced.
+
+8. **Novelty-flag compliance: 0% (first measurement).** This is the baseline. The Drafter introduced or preserved at least 4 novel claims without flagging any. All novelty detection fell to critics. This is the pipeline's newest tracked metric and its weakest dimension.
+
+### Recurring finding types
+
+| Finding type | Runs present | Run 11R evidence |
+|-------------|-------------|----------------|
+| **Silent config/integration gaps** | **9/11** (R2, R3, R5-R11R) | SPEC injection unspecified (M3), Playwright dependency unspecified (M2), REPORT stage omitted (Researcher MAJOR-1), iteration feedback mechanism unspecified (Critic-2 MAJOR-3). 4 instances -- the highest count in a single run. |
+| **Verification/test gaps** | **9/11** (R2, R4-R11R) | Missing success criteria for REQ-09/REQ-10 (Researcher). Prototype quality assumption unvalidated (M4). Token math omits component list (Critic-2 MINOR-1). |
+| **Cross-requirement contradictions** | **4/11** (R4, R9, R11R orig, R11R) | C2: component extraction assumes semantic HTML that REQ-04 never requires. C3: unbounded iteration contradicts cost-saving motivation. Two internal contradictions in one document -- tied for highest with the original Run 11 count. |
+| **Corrector/Drafter introduces new defects** | **8/11** (R2-R9, **NOT R10 or R11R**) | Not present in Run 11R. Second consecutive clean run. Both correctors at zero regressions. |
+| **False safety claims / incorrect verification** | **6/11** (R4-R9, **NOT R10 or R11R**) | Not present in Run 11R. Third consecutive clean run since evidence-gating reached 100%. The protocol has eliminated this failure mode. |
+| **Unflagged novel claims** | **1/11** (R11R -- first measurement) | NEW pattern. 4 unflagged novel claims caught by critics: 4000-token threshold, false-positive UX cost, manifest write timing, unbounded iteration framing. Novelty-flag compliance: 0%. |
+
+### Are the same types of findings recurring?
+
+Yes. Silent config/integration gaps (9/11 runs) and verification/test gaps (9/11 runs) remain the two most persistent categories. Both are document-authoring weaknesses caught reliably by the pipeline. The encouraging signal is that false safety claims have been absent for 3 consecutive runs since evidence-gating reached 100% compliance, and corrector/Drafter regressions have been absent for 2 consecutive runs.
+
+### Is the pipeline finding fewer issues over time?
+
+No. Run 11R's 21 findings is above the 11-run mean of 19.3. With a functioning Critic-2, the pipeline's yield is consistent. The original Run 11's 14 was an artifact of the Critic-2 failure, not a pipeline decline. The pipeline continues to find 15-26 findings per run regardless of document type.
+
+### Is evidence-gating reducing false verification claims?
+
+Yes, conclusively. Four consecutive data points:
+- Runs 6-8 (pre-protocol): fabricated verification in every run
+- Run 9 (82% compliance): 0 false Drafter claims, but Corrector-1 inherited without re-verifying
+- Run 10 (100% compliance): 0 false claims across all writing stages
+- Run 11R (100% compliance): 0 false claims across all writing stages, with self-correction (spawnClaude -> spawnAgent)
+
+The evidence-gating protocol has eliminated fabricated verification in all runs where it was active.
+
+---
+
+## Stage Effectiveness Rankings
+
+For each stage type, contribution is based on findings caught or value added across all runs. Trend compares recent runs to earlier runs.
+
+| Stage | Contribution | Trend | Evidence (11 runs) |
+|-------|-------------|-------|-------------------|
+| **Critic-1** | **HIGH** | **STABLE** | Run 11R: 14 findings (3C/5M/6Mi) -- the entire Round 1 finding output. Found all 3 CRITICALs, all design-logic flaws invisible to the code-focused Researcher. CRITICAL count across runs: 2->1->1->2->1->0->2->1->1->1->3. Run 11R is Critic-1's highest CRITICAL count since Run 4. |
+| **Critic-2** | **HIGH** | **RESTORED (from infrastructure failure)** | Run 11R: 7 findings (0C/3M/4Mi), all genuinely new, zero overlap with Critic-1. The original Run 11 was a total loss (wrong document); this rerun confirms Critic-2 remains essential. MAJOR-3 (feedback mechanism) was the most important Round 2 finding -- the core UX loop was underspecified without it. Across 10 functioning runs + this rerun: consistently finds issues invisible to Critic-1 with zero overlap. |
+| **Researcher** | **HIGH** | **STABLE** | Run 11R: 2 CRITICALs, 4 MAJORs, 6 MINORs, 8 verified claims, 7 failure mode gaps, 6 KB patterns. Zero false positives in 11 runs -- the only stage with a perfect accuracy record. The most architecturally grounded stage in the pipeline. |
+| **Corrector-2** | **HIGH** | **RESTORED** | Run 11R: applied all 7 findings (100%), zero regressions, comprehensive cross-round interaction analysis. Three-tier recovery and iteration feedback mechanism were clean integrations. Across functioning runs: zero regressions ever. |
+| **Corrector-1** | **MEDIUM-HIGH** | **IMPROVING** | Run 11R: zero regressions (second consecutive at 100% evidence-gating). Applied all 14 findings cleanly. Self-review caught interaction issues. Regression series: 0->1->?->2->1->1->2->1->1->0->0. Two consecutive zeros is the best sustained performance in 11 runs. |
+| **Drafter** | **MEDIUM-HIGH** | **IMPROVING** | Run 11R: zero regressions (second consecutive). Integrated all Researcher findings into coherent v1.1. Regression series (R6-R11R): 0->2->2->2->0->0. Two consecutive zeros breaks the R7-R9 streak. Novelty-flag compliance at 0% is a weakness but a newly tracked metric. |
+| **Reader** | **DROPPED** | **N/A** | Absent for 2 consecutive runs. No downstream degradation. Permanently removed. |
+| **Justifier** | **DROPPED** | **N/A** | Absent for 7 consecutive runs (R5-R11R). Permanently removed. |
+
+---
+
+## What's Working
+
+Pipeline behaviors that consistently produce value, with evidence from multiple runs.
+
+**1. Two critique rounds find fundamentally different bug classes (11/11 functioning runs)**
+Run 11R is the clearest demonstration: Critic-1 found design-logic flaws (cosmetic gate, cross-requirement contradiction, cost inconsistency), Critic-2 found operational/UX gaps (interview recovery, false-positive cost, feedback mechanism). Zero overlap. The original Run 11's Critic-2 failure and subsequent rerun proved by contrast how much value Round 2 adds: 7 findings, including 3 MAJORs, were completely invisible to Round 1.
+
+**2. Evidence-gating protocol eliminates fabricated verification claims (3/3 runs at 100% compliance)**
+Run 9 (82%): 0 false Drafter claims. Run 10 (100%): 0 false claims. Run 11R (100%): 0 false claims + self-correction (spawnClaude -> spawnAgent). Pre-protocol Runs 6-8 had fabricated verification in every run. The protocol is the most effective single intervention the pipeline has introduced.
+
+**3. Evidence-gating at 100% correlates with zero Corrector-1 regressions (2/2 runs at 100%)**
+Run 10 (100% compliance): 0 C1 regressions. Run 11R (100% compliance): 0 C1 regressions. Run 9 (82% compliance): 1 C1 regression. The NP-1 candidate pattern now has 2 confirming data points. One more confirming run at 100% compliance with zero C1 regressions makes this a 3-point pattern eligible for KB graduation.
+
+**4. Researcher front-loading prevents downstream waste (11/11 runs, zero false positives)**
+Run 11R: eliminated the entire "codebase accuracy" problem class before the Drafter started. CRITICAL-1 (skill invocation mechanism undefined) alone would have consumed significant critic bandwidth. Across 11 runs: the only stage that has never produced a false positive or introduced a defect.
+
+**5. Corrector-2 is the most reliable stage (11/11 functioning runs, 0 regressions)**
+Run 11R: 7/7 applied, zero regressions, comprehensive cross-round analysis. Self-correction on evidence claims (spawnClaude -> spawnAgent). Across all functioning runs: zero regressions ever, increasingly sophisticated judgment.
+
+**6. Zero-regression runs from both correctors now sustained for 2 consecutive runs (R10-R11R)**
+This is a first in 11 runs. The only prior zero-regression run from both was Run 1 (fixture). Two consecutive zeros on real documents is the strongest sustained corrector performance the pipeline has produced.
+
+**7. Severity calibration remains stable (11 runs)**
+CRITICAL: 5-21% (mean 14%). MAJOR: 38-47% (mean 42%). MINOR: 32-50% (mean 44%). Severity ratings remain meaningful for cross-run comparison.
+
+---
+
+## What's Not Working
+
+Pipeline behaviors that consistently underperform or add no value.
+
+**1. Novelty-flag compliance: 0% (first measurement, worst possible score)**
+The Drafter introduced or preserved at least 4 significant novel claims without flagging any. All novelty detection fell to the critics -- the expensive path. If novelty flagging were enforced, critics could focus on structural analysis rather than claim verification. This is the pipeline's weakest dimension and was invisible before this metric was tracked.
+
+**2. Silent config/integration gaps persist as the most common finding type (9/11 runs)**
+Run 11R had 4 instances -- the highest count in a single run: SPEC injection unspecified, Playwright dependency unspecified, REPORT stage omitted, iteration feedback mechanism unspecified. This is a document-authoring weakness, not a pipeline failure. The pipeline catches these reliably but authors continue to produce them at a steady rate.
+
+**3. Drafter regressions were zero this run but the historical record is mixed**
+The reclassification of the 4000-token threshold (from regression to preserved-from-input) changes the narrative: the R6-R11R series is now 0->2->2->2->0->0 rather than 0->2->2->2->0->1. Two consecutive zeros is encouraging but the R7-R9 streak of 2/run preceded it. Need 1-2 more zero-regression runs to confirm the trend is real vs. coincidence with simpler documents.
+
+**4. Cross-requirement contradictions are an emerging pattern (4/11 runs)**
+Run 11R had 2 internal contradictions (semantic HTML assumption vs REQ-04, unbounded iteration vs cost-saving). This pattern appeared in Runs 4, 9, and both Run 11 variants. It is harder to catch than other finding types because it requires holding two distant sections in context simultaneously. Only Critic-1 has caught these -- Critic-2 and the Researcher have not.
+
+---
+
+## So What?
+
+- **The Critic-2 rerun proved Round 2 is not redundant.** The original Run 11 left 7 findings undiscovered (3 MAJOR, 4 MINOR), including MAJOR-3 (iteration feedback mechanism) which was essential for the core UX loop. The original report estimated "8-10 findings left on the table"; actual was 7. This validates both the two-round architecture and the decision to rerun when Critic-2 fails.
+
+- **Evidence-gating at 100% compliance now has 2 consecutive runs with zero regressions from BOTH Drafter and Corrector-1 (R10-R11R).** This is the pipeline's strongest sustained quality signal. If Run 12 continues the pattern, evidence-gating becomes the confirmed structural fix for the regression problem that resisted 3+ cycles of prompt-level changes.
+
+- **Novelty-flag compliance is 0% and is the next intervention to implement.** The Drafter's failure mode is not fabricating evidence (evidence-gating handles that) -- it is introducing or preserving novel claims without flagging them, forcing critics to play detective. Adding a "mark any claim not from the Researcher output with [NEW -- NEEDS JUSTIFICATION]" self-check would make invented content visible and shift detection earlier in the pipeline.
+
+- **21 findings, 21 applied, 0 regressions, 0 false evidence claims -- the cleanest full-pipeline execution in 11 runs.** This validates the 6-stage pipeline (Reader and Justifier dropped) as the production configuration. No stage was redundant. Every stage contributed unique value.
+
+- **The pipeline generalizes to PRDs.** Run 11R is the first PRD (vs. plans, fix documents, reference guides) processed by the pipeline. It found 3 CRITICALs, 8 MAJORs, and 10 MINORs with 100% application rate. The pipeline's core value proposition -- finding bugs humans miss -- holds across document types.

--- a/tests/double-critique/effectiveness-2026-03-27.md
+++ b/tests/double-critique/effectiveness-2026-03-27.md
@@ -1,0 +1,106 @@
+# Double-Critique Pipeline -- Effectiveness Report
+
+**Date:** 2026-03-27
+**Run number:** 12 (cumulative)
+**Author:** Effectiveness analysis agent
+
+---
+
+## This Run
+
+Run 12 critiqued a second iteration of the Automated UI Design Stage PRD and surfaced 17 findings across two critique rounds with 100% application rate, but the Drafter introduced 3 regressions -- the worst regression count since tracking began -- breaking the two-run zero-regression streak (R10-R11R).
+
+- **Document critiqued:** Automated UI Design Stage PRD v1.0 -> v1.3 (`.ai-workspace/plans/2026-03-27-design-stage-prd.md`)
+- **Total findings: 17** (CRITICAL: 1, MAJOR: 7, MINOR: 9)
+- **Application rate: 100%** (17/17)
+- **Drafter regressions: 3** (keyword example contradiction, silent token divergence, uncapped YAML loop)
+- **Corrector-1 regressions: 1** (dismissed file-listing UX as "implementation detail")
+- **Evidence-gating compliance: 95%** (Drafter 92%, Corrector-1 100%)
+- **False verification claims: 0**
+- **Novelty-flag compliance: ~90%** (14 tagged of ~15-16 novel claims)
+
+### Stage contributions
+
+| Stage | Contribution | Key output |
+|-------|-------------|-----------|
+| Critic-1 | **HIGHEST (MVP)** | 9 findings (1C/3M/5Mi). Found only CRITICAL + all 3 Drafter regressions |
+| Researcher | **HIGH** | 11 codebase verifications, 3 MAJOR gaps, keyword false-positive analysis, 0 false positives |
+| Critic-2 | **HIGH** | 8 findings (0C/4M/4Mi), zero overlap with Critic-1. Found JS+no-deps feasibility conflict |
+| Corrector-2 | **HIGH** | 8/8 applied, zero regressions. Most reliable stage |
+| Drafter | **MEDIUM** | 14 changes but 3 regressions -- worst single-run count |
+| Corrector-1 | **MEDIUM** | 9/9 applied but 1 regression (dismissed UX concern) |
+
+---
+
+## Cross-Run Trends
+
+### Finding counts across all runs
+
+| Run | Date | Document | C | M | Mi | Total | App% | D-reg | C1-reg |
+|-----|------|----------|---|---|-----|-------|------|-------|--------|
+| 1 | 03-08 | Rate Limiter (fixture) | 3 | 7 | 8 | 18 | 94% | ? | 0 |
+| 2 | 03-08 | E2E Bug Fix | 2 | 6 | 7 | 15 | 93% | ? | 1 |
+| 3 | 03-14 | Phase 6 Plan | 4 | 11 | 11 | 26 | 100% | ? | ? |
+| 4 | 03-15 | Post-MVP Plan | 4 | 9 | 6 | 19 | 100% | ? | 2 |
+| 5 | 03-17 | Normalize Stage | 2 | 8 | 7 | 17 | 100% | ? | 1 |
+| 6 | 03-21 | Pipeline Failure Fix | 3 | 7 | 8 | 18 | 94% | 0 | 1 |
+| 7 | 03-21 | CI/CD Reference | 3 | 8 | 9 | 20 | 100% | 2 | 2 |
+| 8 | 03-22 | Pipeline Bug Fix | 2 | 9 | 9 | 20 | 100% | 2 | 1 |
+| 9 | 03-22 | PRD Workflow | 3 | 7 | 8 | 18 | 88% | 2 | 1 |
+| 10 | 03-22 | Live Summary Report | 1 | 9 | 10 | 20 | 100% | 0 | 0 |
+| 11R | 03-24 | Design Stage PRD | 3 | 8 | 10 | 21 | 100% | 0 | 0 |
+| **12** | **03-27** | **Design Stage PRD v2** | **1** | **7** | **9** | **17** | **100%** | **3** | **1** |
+
+### Regression tracking table
+
+| Run | Drafter reg. | C1 reg. | Evidence-gating | Novelty-flag |
+|-----|-------------|---------|-----------------|--------------|
+| 9 | 2 | 1 | 82% | N/A |
+| 10 | 0 | 0 | 100% | N/A |
+| 11R | 0 | 0 | 100% | 0% |
+| **12** | **3** | **1** | **95%** | **~90%** |
+
+**Key trends:**
+- R10-R11R zero-regression streak broken. 3 Drafter regressions is worst count tracked.
+- Sub-100% evidence-gating correlates with regressions in all 4 measured runs.
+- Novelty-flag compliance jumped from 0% to ~90% (fastest metric improvement in pipeline history).
+- Finding count (17) tied for second-lowest, reflecting higher-quality input (second pass on same document).
+
+---
+
+## Stage Effectiveness Rankings
+
+| Stage | Contribution | Trend |
+|-------|-------------|-------|
+| Critic-1 | HIGH | STABLE |
+| Critic-2 | HIGH | STABLE (peak) |
+| Researcher | HIGH | STABLE |
+| Corrector-2 | HIGH | STABLE (peak) |
+| Drafter | MEDIUM | DECLINING (this run) |
+| Corrector-1 | MEDIUM | DECLINING (slight) |
+
+---
+
+## What's Working
+
+1. **Two critique rounds find different bug classes** (12/12 runs) -- zero overlap between Critic-1 and Critic-2 in Run 12.
+2. **Evidence-gating eliminates fabricated verification** (3 consecutive runs, 0 false claims).
+3. **Researcher front-loading** (12/12 runs, zero false positives ever).
+4. **Corrector-2 is the most reliable stage** (12/12 runs, 0 regressions ever).
+5. **Novelty-flag compliance jumped 0% -> ~90%** in one run.
+
+## What's Not Working
+
+1. **Drafter regressions not structurally solved** -- R10-R11R zeros were a streak, not a new baseline. Needs "consistency pass" instruction.
+2. **NP-1 pattern ambiguous** -- 95% evidence-gating -> regressions, but regressions were content errors not evidence errors.
+3. **Silent config/integration gaps persist** (10/12 runs) -- same categories keep appearing.
+
+---
+
+## So What?
+
+- Run 12 breaks the zero-regression streak with 4 total regressions (3 Drafter + 1 Corrector-1). Evidence-gating at 95% instead of 100% correlates with the return. The Drafter needs a structural "re-read for internal consistency" instruction.
+- The pipeline still delivers: 17 findings caught, 100% applied, zero false claims. Even with a regression-heavy Drafter, critics caught everything. Final v1.3 is clean.
+- Novelty-flag compliance jumped 0% -> ~90%. Fastest metric improvement in history.
+- Enforce 100% evidence-gating compliance or accept regression risk. The data across 4 measured runs is consistent.
+- Critic-1 remains the safety net. Found the only CRITICAL and all 3 Drafter regressions.

--- a/tests/double-critique/retrospective-2026-03-24.md
+++ b/tests/double-critique/retrospective-2026-03-24.md
@@ -1,0 +1,140 @@
+# Double-Critique Pipeline -- Retrospective Report
+
+**Date:** 2026-03-24 (Run 11 REVISED)
+**Runs covered:** 11 (Run 1 through Run 11R, 2026-03-08 to 2026-03-24)
+**Based on:** effectiveness-2026-03-24.md (Run 11 REVISED -- Design Stage PRD)
+**Prior version:** retrospective-2026-03-22.md covered Runs 1-10
+**Note:** This retrospective supersedes the original Run 11 retrospective, which was based on broken Critic-2 data. All assessments below reflect the corrected run with all 21 findings.
+
+---
+
+## Summary
+
+Run 11 REVISED is the cleanest full-pipeline execution in 11 runs: 21 findings, 100% application rate, zero regressions from both Drafter and Corrector-1, zero false verification claims, and 100% evidence-gating compliance. This is the second consecutive run hitting all ideal values (alongside Run 10), breaking the R7-R9 regression streak decisively. The Critic-2 rerun proved Round 2 is not redundant -- 7 findings (3 MAJOR) were invisible to Round 1. The pipeline generalizes to PRDs (first non-plan document type). Novelty-flag compliance is 0% -- a new metric and the pipeline's weakest dimension. NP-1 (evidence-gating at 100% -> zero C1 regressions) now has 3 confirming data points and is graduated to the knowledge base.
+
+---
+
+## KEEP -- What's Working Well
+
+**[Two-round critic architecture]** -- Two independent critics find fundamentally different bug classes with zero overlap across 11 runs. The Critic-2 rerun proved this by contrast: the original Run 11's Critic-2 failure left 7 findings undiscovered (3 MAJOR), including MAJOR-3 (iteration feedback mechanism) which was essential for the core UX loop. -- Evidence: 11/11 functioning runs complementary. Run 11R: Critic-1 found design-logic flaws (cosmetic gate, cross-requirement contradiction, cost inconsistency); Critic-2 found operational/UX gaps (interview recovery, false-positive cost, feedback mechanism). Zero overlap. -- Action: No change. Most proven structural decision (P5).
+
+**[Researcher front-loading]** -- Zero false positives in 11 runs. The only stage with a perfect accuracy record. Run 11R: 2 CRITICALs, 4 MAJORs, 6 MINORs, 8 verified codebase claims, 7 failure mode gaps, 6 KB patterns cross-referenced. Eliminated the entire "codebase accuracy" problem class before the Drafter started. -- Evidence: 11/11 runs, consistently the most architecturally grounded stage. Freed Critic-1 to focus on higher-level logic analysis (Critic-1 produced its highest-ever CRITICAL count: 3). -- Action: Keep as-is.
+
+**[Evidence-gating protocol]** -- Third consecutive run at 100% compliance. Zero false verification claims across all three (R9 at 82%, R10 at 100%, R11R at 100%). Self-correction observed in R11R: Corrector-2 refined `spawnClaude` to `spawnAgent` (actual export at spawner.ts:10). Pre-protocol Runs 6-8 had fabricated verification in every run. -- Evidence: 3/3 runs with protocol active at 100% compliance had 0 false claims AND 0 regressions from both writing stages. The protocol is the most effective single intervention the pipeline has introduced. -- Action: Keep as mandatory. 100% compliance is the standard, not a stretch target.
+
+**[Evidence-gating at 100% correlates with zero regressions -- NP-1 GRADUATED]** -- Run 11R is the third data point: R9 (82% compliance, 1 C1 regression), R10 (100%, 0 regressions), R11R (100%, 0 regressions). The pattern now has 3 data points with clear directionality and meets all KB graduation criteria. -- Evidence: The only intervention that correlated with zero Corrector-1 regressions after 3 retrospective cycles of prompt changes failed (F2). -- Action: Graduated to knowledge base as P55 (see Graduation Assessment below).
+
+**[Corrector-2 reliability]** -- Perfect record: 0 regressions in 11/11 functioning runs. Run 11R: applied all 7 findings (100%), designed three-tier recovery, confirmation prompt before interview, previous-prototype-in-prompt for re-generation. Self-correction on evidence claims. -- Evidence: Zero regressions ever. 8th consecutive run with non-trivial design contribution. -- Action: No change.
+
+**[6-stage pipeline as production configuration]** -- Second run without Reader, zero downstream degradation. No stage was redundant in Run 11R -- every stage contributed unique value. -- Evidence: Run 10 + Run 11R both clean without Reader. Justifier absent for 7 consecutive runs with no missed findings. -- Action: Confirmed permanent: Researcher, Drafter, Critic-1, Corrector-1, Critic-2, Corrector-2.
+
+**[Severity calibration stability]** -- Distributions remain consistent across 11 runs and 6 document types (fixture, bug-fix plan, implementation plan, reference guide, recommendation report, PRD). -- Evidence: CRITICAL 5-21% (mean 14%), MAJOR 38-47% (mean 42%), MINOR 32-50% (mean 44%). Run 11R at 14/38/48 -- within all bands. -- Action: No change.
+
+**[Application rate]** -- Four consecutive runs at 100%. 11-run mean: 97.2%. -- Evidence: Run 11R: 21/21 applied. The pipeline produces findings that are overwhelmingly accepted as valid. -- Action: No change.
+
+---
+
+## CHANGE -- What Should Be Modified
+
+**[Novelty-flag compliance must be tracked and improved]** -- Run 11R measured 0% (first measurement). The Drafter introduced or preserved at least 4 novel claims without flagging any. All novelty detection fell to critics -- the expensive path. -- Evidence: 4 unflagged novel claims: 4000-token threshold (M5), false-positive UX cost framing (MAJOR-2), manifest write timing assumption (M1), unbounded iteration cost framing (C3). If flagged, critics could have focused on structural analysis. -- Action: Add `[NEW -- NEEDS JUSTIFICATION]` self-check to Drafter prompt. Measure novelty-flag compliance as a first-class metric starting Run 12.
+
+**[Drafter regression monitoring -- cautiously optimistic]** -- Two consecutive zeros (R10-R11R) breaks the R7-R9 streak of 2/run. The reclassification of the 4000-token threshold (preserved from input PRD, not Drafter-invented) supports this. -- Evidence: Series (R6-R11R): 0->2->2->2->0->0. Two consecutive zeros at 100% evidence-gating. But evidence-gating alone cannot prevent novelty-based regressions (NP-2 discovery). -- Action: Continue monitoring. If R12 maintains zero regressions with novelty-flagging active, credit the combined intervention (evidence-gating + novelty-flagging).
+
+**[Config/integration gap checklist for document authors]** -- Still the most common finding type (9/11 runs). Run 11R had the highest single-run count: 4 instances. -- Evidence: SPEC injection unspecified, Playwright dependency unspecified, REPORT stage omitted, iteration feedback mechanism unspecified. -- Action: Repeat recommendation from R10 retrospective: prompt-level checklist for document authors. This is the 4th consecutive recommendation without implementation.
+
+---
+
+## ADD -- New Pipeline Stages or Modifications to Try
+
+**[Novelty-flag self-check for Drafter]** -- Add `[NEW -- NEEDS JUSTIFICATION]` tag requirement for any claim not directly derived from Researcher output or source document. -- Evidence: Run 11R: 0% novelty-flag compliance, 4 unflagged novel claims. All were caught by critics, but earlier detection (at Drafter stage) would reduce critic workload and shift the pipeline toward catching structural issues. -- Action: Implement for Run 12. Track compliance rate as a metric.
+
+**[Cross-requirement contradiction detection prompt for Critic-1]** -- This finding type appeared in 4/11 runs (R4, R9, R11 original, R11R) and was caught exclusively by Critic-1. It requires holding two distant sections in context simultaneously. -- Evidence: Run 11R: 2 contradictions (semantic HTML vs REQ-04, unbounded iteration vs cost motivation). Neither Critic-2 nor Researcher has ever caught this type. -- Action: Add to Critic-1 prompt: "Explicitly check whether each requirement's assumptions are contradicted by other requirements."
+
+**[Automated diff between Corrector-1 input and output]** -- Fourth consecutive retrospective recommendation. Still not implemented. Now less urgent given two consecutive zero-regression runs, but valuable for diagnostics when regressions recur. -- Evidence: When regressions do occur (R2-R9 average: 1.1/run), root cause analysis is opaque without a diff. -- Action: Deprioritize below novelty-flag. Implement if capacity allows.
+
+---
+
+## DROP -- Not Pulling Its Weight
+
+**[Reader stage -- confirmed permanent drop]** -- 9 runs of zero evaluative findings + 2 clean runs without it. No downstream stage reported missing context in either Run 10 or Run 11R. -- Evidence: 11 runs total (9 with Reader contributing nothing, 2 without it with no quality loss). -- Action: Permanently removed.
+
+**[Justifier stage -- confirmed permanent drop]** -- Absent for 7 consecutive runs (R5-R11R). No missed findings. -- Evidence: 7 runs without it, zero observable quality loss. -- Action: Permanently removed.
+
+---
+
+## NEW PATTERNS -- Candidate Patterns Discovered
+
+### NP-1: Evidence-gating at 100% compliance eliminates writing-stage regressions (GRADUATED as P55)
+
+- **Plain-language name:** When everyone shows their receipts, nobody makes stuff up
+- **What:** Three consecutive data points confirm: 100% evidence-gating compliance correlates with zero regressions from both Drafter and Corrector-1.
+- **Why:** Evidence-gating forces each factual claim to be anchored to a specific file, line number, and quoted code. This prevents fabricated verification that caused regressions in Runs 6-9.
+- **Evidence:** R9 (82% compliance): 3 total regressions (2 Drafter + 1 Corrector-1). R10 (100%): 0 regressions. R11R (100%): 0 regressions. Pre-protocol Runs 6-8: fabricated verification in every run.
+- **Analogy:** Like requiring receipts for expense reports -- when people know they must show proof, they stop padding the numbers.
+- **Status:** GRADUATED to `01-proven-patterns.md` as P55. 3 data points (1 negative control + 2 positive confirmations). Meets stability (3+ runs), evidence (measured numbers), and generalizability (applies to any multi-stage pipeline with verification claims) criteria.
+- **Cross-ref:** P11 (external artifacts), P13 (compliance hierarchy), F9 (self-scoring bias).
+
+### NP-2: Evidence-gating does NOT fix Drafter regressions (separate failure mode) -- UPDATED
+
+- **Plain-language name:** Showing receipts only works for things you bought -- it cannot catch things you invented
+- **What:** Evidence-gating at 100% compliance prevents fabricated verification but cannot prevent the Drafter from introducing novel claims because there is no existing fact to verify against.
+- **Why:** Evidence-gating checks "did you actually read file X at line Y?" It does not check "is this claim derived from any source, or did you invent it?" Novelty and fabrication are orthogonal failure modes.
+- **Evidence:** Run 11R: 100% evidence-gating compliance, 0% novelty-flag compliance. 4 novel claims caught only by critics. The reclassification of the 4000-token threshold as "preserved from input" means the Drafter regression count is 0 in R11R, but the underlying novelty-detection gap remains -- those 4 claims were detected by critics, not by any self-check.
+- **Status:** 2 data points at 100% compliance (R10 zero regressions, R11R zero regressions but 4 unflagged novel claims). The intervention (novelty-flagging) has not been tested yet. Needs R12 with novelty-flagging active.
+- **Cross-ref:** F2 (behavioral prose), NP-1/P55 (evidence-gating for verification).
+
+### NP-3: Pipeline generalizes across document types without configuration changes
+
+- **Plain-language name:** The quality inspector works on any product, not just the one it was trained on
+- **What:** Run 11R is the first PRD processed by the pipeline (vs. plans, fix documents, reference guides). It found 3 CRITICALs, 8 MAJORs, 10 MINORs with 100% application rate -- all within established bands.
+- **Evidence:** 6 document types across 11 runs: fixture (R1), bug-fix plan (R2), implementation plan (R3-R6, R8, R10), reference guide (R7), recommendation report (R9), PRD (R11R). Finding counts, severity distributions, and application rates are all consistent.
+- **Status:** 1 data point for PRDs specifically. Pattern is well-established for plans (8 runs). Hold.
+
+---
+
+## NEW ANTI-PATTERNS -- Candidate Anti-Patterns Discovered
+
+### NAP-1: No artifact-identity validation between pipeline stages (from original Run 11)
+
+- **Plain-language name:** The proofreader checked the wrong essay
+- **What:** The pipeline has no mechanism to verify that each stage receives the correct input artifact. The original Run 11 had Critic-2 review a stale document from a prior run.
+- **Why it fails:** Stages are connected by file paths. If the wrong path is passed, the stage operates on the wrong document silently.
+- **Evidence:** Original Run 11: entire Round 2 wasted. 10 confident findings against the wrong document. The rerun fixed the immediate issue but the structural vulnerability remains.
+- **Mitigation:** Document-identity assertion at stage entry (title match, hash check, or path verification).
+- **Status:** 1 data point. The rerun prevented data loss but did not fix the underlying vulnerability.
+
+### NAP-2: Unflagged novel claims in Drafter output (first measurement)
+
+- **Plain-language name:** The translator added sentences that were not in the original
+- **What:** The Drafter introduces or preserves quantitative claims, cost framings, and mechanism assumptions not present in source material, without flagging them as novel.
+- **Why it fails:** Synthesis inherently involves gap-filling. Without a novelty-flag requirement, gap-filling is invisible until critics detect it.
+- **Evidence:** Run 11R: 0% novelty-flag compliance. 4 unflagged novel claims caught by critics: 4000-token threshold (M5), false-positive UX cost framing (MAJOR-2), manifest write timing (M1), unbounded iteration framing (C3).
+- **Status:** First measurement. Baseline established at 0%.
+
+---
+
+## Knowledge Base Graduation Assessment
+
+Five candidate findings assessed against the three criteria (stability: 3+ runs, evidence: measured numbers, generalizability: applies beyond double-critique):
+
+1. **NP-1: Evidence-gating at 100% eliminates writing-stage regressions** -- Stability: YES (3 data points: R9 negative control at 82% with regressions, R10 positive at 100% with zero, R11R positive at 100% with zero). Evidence: YES (measured compliance % and regression counts with clear inverse correlation). Generalizability: YES (the principle -- "require proof artifacts for verification claims" -- applies to any multi-stage pipeline, not just double-critique; it is P11 applied to verification with P13 Tier 2 enforcement). **Decision: GRADUATE as P55 in `01-proven-patterns.md`. This is the first KB graduation since Run 6 (2026-03-21) and breaks a five-run streak with no graduations.**
+
+2. **NP-2: Evidence-gating does not prevent novelty-based regressions** -- Stability: 2 data points at 100% compliance. NOT YET (needs 3+). Evidence: YES. Generalizability: YES. **Decision: Hold for Run 12 with novelty-flagging active.**
+
+3. **Corrector-2 zero-regression record (11/11 functioning runs)** -- Stability: YES (11 runs). Evidence: YES. Generalizability: YES (final-stage advantage). **Decision: Hold for 1 more functioning run. If 12/12, graduate as "Final-stage correctors outperform mid-pipeline correctors."**
+
+4. **Cross-requirement contradictions as high-value finding type (4/11 runs)** -- Stability: PARTIAL. Evidence: YES. Generalizability: PARTIAL. **Decision: Hold.**
+
+5. **Pipeline generalizes across document types (NP-3)** -- Stability: 1 data point for PRDs. NOT YET. **Decision: Hold for 2+ more non-plan documents.**
+
+**KB graduation result: 1 new entry (P55).** This breaks the five-consecutive-run streak with no graduations. P55 is the scoped claim: "Evidence-gating at 100% compliance eliminates writing-stage regressions in multi-stage pipelines."
+
+---
+
+## Next Run Priorities
+
+1. **Implement novelty-flag self-check for Drafter.** Add `[NEW -- NEEDS JUSTIFICATION]` tag requirement for claims not derived from Researcher output. Track novelty-flag compliance as a first-class metric. This is the pipeline's weakest measured dimension (0%) and the most impactful single intervention available.
+
+2. **Add cross-requirement contradiction prompt to Critic-1.** This finding type (4/11 runs, exclusively caught by Critic-1) would benefit from prompted detection rather than relying on cold-reading. Low implementation cost (one sentence in prompt), potentially high impact on the highest-value finding category.
+
+3. **Implement document-identity validation between stages.** The original Run 11's Critic-2 failure demonstrated that artifact-routing bugs are invisible to stage-quality metrics. A title-match or content-hash check at stage entry would prevent a repeat. This is the only infrastructure vulnerability discovered in 11 runs.

--- a/tests/double-critique/retrospective-2026-03-27.md
+++ b/tests/double-critique/retrospective-2026-03-27.md
@@ -1,0 +1,88 @@
+# Double-Critique Pipeline -- Retrospective (Run 12)
+
+**Date:** 2026-03-27
+**Document:** Automated UI Design Stage PRD v1.0 -> v1.3
+
+---
+
+What is this report? This is a team retrospective -- like a post-game huddle where we decide what to keep doing, what to change, and what to stop doing. It covers Run 12 of the double-critique pipeline (2026-03-27) applied to the Automated UI Design Stage PRD, and distills findings into actionable next steps.
+
+---
+
+## KEEP
+
+**Two-round critic architecture** -- Two independent cold reviewers find fundamentally different bug classes with zero overlap. -- Evidence: 12/12 runs, Run 12 Critic-1 found design-logic flaws (undefined behavior, contradictions), Critic-2 found cross-requirement feasibility conflicts. -- Action: Non-negotiable. Never reduce to single critic.
+
+**Researcher front-loading** -- Fact-checking and justification analysis before drafting prevents downstream waste. -- Evidence: 12/12 runs, zero false positives ever. Run 12: pre-answered 5+ findings, caught inflated checkpoint stat. -- Action: Keep as Stage 1.
+
+**Evidence-gating protocol** -- VERIFIED/UNVERIFIED format eliminates fabricated verification claims. -- Evidence: 3 consecutive runs (R10-R12) with zero false claims. Pre-protocol runs had fabrication in every run. -- Action: Keep and enforce at 100%.
+
+**Corrector-2 reliability** -- Final corrector has never introduced a defect in any run. -- Evidence: 12/12 runs, 0 regressions. Run 12: 8/8 applied cleanly. -- Action: Keep unchanged.
+
+**6-stage configuration** -- Current pipeline (Researcher, Drafter, Critic-1, Corrector-1, Critic-2, Corrector-2) is the optimal configuration. -- Evidence: No redundant stages in Run 12. Reader and Justifier correctly dropped. -- Action: Keep.
+
+**100% application rate streak** -- 5 consecutive runs at 100% means findings are actionable, not noise. -- Evidence: R8-R12 all at 100%. Updated 12-run mean: 97.4%. -- Action: Keep monitoring.
+
+---
+
+## CHANGE
+
+**Drafter needs "consistency pass" instruction** -- 3 regressions in Run 12 (worst count tracked), all internal contradictions detectable by re-reading own output. The Drafter wrote keyword removal rationale and contradictory keyword examples in the same section. -- Evidence: Regression series R6-R12: 0->2->2->2->0->0->3. Prompt changes alone don't work (5 retrospective cycles). -- Action: Add explicit instruction to `references/stage-prompts-core.md` Stage 2: "After drafting, re-read every section where you made changes. For each change, check: does any other section in the document contradict this change? If yes, fix the contradiction before proceeding."
+
+**Enforce 100% evidence-gating as hard requirement** -- 4/4 measured data points: sub-100% correlates with regressions, 100% correlates with zero. Run 12 at 95% had 4 regressions. -- Evidence: R9 (82%) -> 3 reg. R10 (100%) -> 0. R11R (100%) -> 0. R12 (95%) -> 4. -- Action: Change Drafter and Corrector-1 prompts from "you MUST use the format" to "If ANY verification claim lacks evidence, STOP and re-verify before proceeding. 100% compliance is required."
+
+**Config/integration gap checklist** -- Same finding type in 10/12 runs (dashboard integration, path portability, failure count persistence). Pipeline catches them but documents keep producing them. -- Evidence: Run 12: 3 config/integration findings. 10/12 runs historically. -- Action: Add to Researcher prompt: "Explicitly check for: cross-stage data contracts, path portability, state persistence across restarts, dashboard/UI integration points."
+
+---
+
+## ADD
+
+**Drafter "re-read for internal consistency" self-check** -- New post-drafting step that specifically targets the contradiction failure mode (Run 12's worst regression type). -- Evidence: All 3 Drafter regressions in Run 12 were internal contradictions. -- Action: Add as step in Stage 2 prompt after the existing self-review checklist.
+
+---
+
+## DROP
+
+Nothing new to drop. Reader (dropped R9) and Justifier (dropped R5) remain dropped with no degradation.
+
+---
+
+## NEW PATTERNS
+
+**NP-2: Novelty-flag compliance is the fastest-improving metric**
+- **What:** Drafter novelty-flag tagging went from 0% (R11R) to ~90% (R12) in a single run after adding the `NEW_CLAIM:` format instruction.
+- **Why:** Explicit format requirements convert Tier 4 behavioral prose into Tier 2 artifact enforcement. Same mechanism that made evidence-gating work.
+- **Evidence:** R11R: 0% (no tags). R12: 14 tags on ~15-16 novel claims = ~90%.
+- **Analogy:** Like requiring a "source:" citation on every Wikipedia edit -- it doesn't prevent bad edits but makes them visible for review.
+
+**NP-3: Second-pass critique yields fewer findings but maintains MAJOR detection**
+- **What:** Running double-critique on a second iteration of the same document produces fewer total findings (21 -> 17) but the MAJOR detection rate holds (38% -> 41%).
+- **Why:** Big problems were caught in the first pass. Residual issues skew MINOR. But cross-requirement contradictions and feasibility conflicts still emerge because they depend on the specific changes made, not the document's baseline quality.
+- **Evidence:** R11R (first pass): 21 findings, 38% MAJOR. R12 (second pass): 17 findings, 41% MAJOR.
+- **Analogy:** Like proofreading a paper twice -- the second pass catches fewer typos but still finds structural arguments that only become visible after the first round of fixes.
+
+---
+
+## NEW ANTI-PATTERNS
+
+**NAP-1: Drafter regressions cluster around content contradictions, not evidence errors**
+- **What:** Evidence-gating prevents fabricated verification but cannot prevent the Drafter from writing contradictory content across sections.
+- **Why:** Evidence-gating checks "did this thing exist?" -- it doesn't check "does this thing I wrote agree with that other thing I wrote 50 lines up?"
+- **Evidence:** R12: 3 regressions at 95% evidence-gating. All 3 were section-to-section contradictions, none were evidence fabrication.
+- **Analogy:** Like a fact-checker who verifies every quote is real but doesn't notice the article contradicts itself between paragraphs.
+
+**NAP-2: Zero-regression streaks are correlation, not causation**
+- **What:** The R10-R11R zero-regression streak (both 100% evidence-gating) broke at R12, proving the streak was not a permanent state change.
+- **Why:** Multiple factors contribute to regressions beyond evidence-gating: document complexity, number of changes, Drafter attention to consistency.
+- **Evidence:** R10: 0 reg (100% EG). R11R: 0 reg (100% EG). R12: 4 reg (95% EG). Two-run streaks don't establish baselines.
+- **Analogy:** Like saying "I haven't gotten a flat tire in 2 months, so I'm immune" -- then getting one.
+
+---
+
+## Next Run Priorities
+
+1. **Add Drafter consistency-pass instruction** to `references/stage-prompts-core.md` Stage 2. After drafting and before self-review, add: "Re-read every section where you made changes. For each change, verify no other section contradicts it." This directly targets the 3 Drafter regressions from Run 12.
+
+2. **Enforce 100% evidence-gating as hard requirement** in Drafter and Corrector-1 prompts. Change from "you MUST use the format" to "100% compliance is required. If any claim lacks evidence, STOP and re-verify." 4/4 data points confirm the correlation.
+
+3. **Monitor novelty-flag compliance** -- confirm it sustains above 80% in Run 13. If it drops, the instruction needs reinforcement (same trajectory as evidence-gating: R9 introduced -> R10 hit 100%).


### PR DESCRIPTION
## Summary
- Add effectiveness and retrospective reports for double-critique Runs 11R and 12
- Run 12 critiqued the Automated UI Design Stage PRD through a full 6-stage pipeline
- P55 graduated to knowledge base (evidence-gating at 100% = zero regressions)
- Novelty-flag compliance jumped 0% to ~90% in one run

## Test plan
- [ ] Reports render correctly in GitHub markdown preview
- [ ] No sensitive data in reports