### PR TITLE
docs: add 8 new ideas to harness roadmap

### DIFF
--- a/docs/harness-roadmap/roadmap-backlog.md
+++ b/docs/harness-roadmap/roadmap-backlog.md
@@ -10,4 +10,7 @@ Parking lot for new ideas that come up between releases. During release planning
 ## Backlog Items
 
 - [P5] One PR per story in pipeline -- each story gets own branch/PR instead of one big branch (candidate for R2)
-- [P4] Evaluate which R2-R4 prompt-based items should be skills -- audit during R2 planning to ensure skill-creator can improve them in R3
+- [P4] Evaluate which stages/prompts should be skills -- audit during R2 planning: Normalize (73 lines, 1 agent) is a strong candidate for full skill conversion; Spec/Plan too complex (orchestration logic) but their prompt text can be extracted into skills. Deferred to R2.
+- [P4] 3-tier memory model: persistent (brand voice, SOP), per-session (user query, chat history), searchable (knowledge-base, vector DB) -- aligns with R3 memory items (SQL DB, Claude-Mem)
+- [P6] Cost breakdown by agent and model type in pipeline run -- extend CostTracker to track model field per AgentCostEntry (candidate for R2)
+- [P2] Dashboard visible from Normalize stage -- show stage progress from pipeline start, not just EXECUTE; use frontend design skill for UI (candidate for R2)

--- a/docs/harness-roadmap/roadmap-release-1.md
+++ b/docs/harness-roadmap/roadmap-release-1.md
@@ -18,16 +18,44 @@ Does NOT apply to: Story 1 (MCP infra -- code), Story 2 (tool permissions -- cod
   - PR 1c: deferred loading support
   - PR 1d: README docs
 
+**3. Simple scales better than complex.** Use simple algorithms and data structures. Fancy algorithms are slow when N is small -- and N is usually small in our context (stories per PRD, agents per stage, waves per run). Prefer straightforward loops over clever abstractions. Only optimize when profiling proves a bottleneck.
+
+Applies to: all stories, all releases.
+
+---
+
+## Pre-R1: Baseline Current Pipeline
+
+Before any R1 code changes, capture a performance baseline for comparison:
+
+1. Run the full pipeline once on a test PRD (use an existing PRD from `../hive-mind-design/`)
+2. Save all outputs to `../hive-mind-design/baselines/pre-r1/`:
+   - `cost-log.jsonl` -- per-agent cost and duration
+   - `manager-log.jsonl` -- pipeline event log
+   - `execution-plan.json` -- story metadata and pass/fail
+   - `report-card.md` -- accumulated scorecard
+   - `live-report.md` -- final dashboard snapshot
+   - `consolidated-report.md` -- full pipeline summary
+3. Record summary metrics in a `baseline-summary.md`:
+   - Total cost (USD)
+   - Total elapsed time
+   - Story pass rate (passed/total)
+   - Test pass rate
+   - Number of retries
+   - Agent count by type
+
+This baseline is referenced by the Exit Criteria ("scorecard >= baseline") and will be used for R1 retrospective comparison.
+
 ---
 
 ## Dependencies
 
 ```
 Item 1 (MCP Phase 1) --> Items 2, 3 (WebSearch, Context7 need MCP)
-Items 4, 5, 6 have no dependencies (can start immediately)
+Items 4, 5, 6, 7 have no dependencies (can start immediately)
 ```
 
-**Recommended order:** Start items 4, 5, 6 in parallel with item 1. Items 2, 3 after item 1 lands.
+**Recommended order:** Start items 4, 5, 6, 7 in parallel with item 1. Items 2, 3 after item 1 lands.
 
 ---
 
@@ -230,13 +258,43 @@ Items 4, 5, 6 have no dependencies (can start immediately)
 
 ---
 
+### Story 7: Clear Old .ai-workspace Before New Pipeline Run
+
+**Goal:** Prevent stale artifacts from previous pipeline runs from confusing the current run.
+
+**What to build:**
+1. At pipeline start (before NORMALIZE), check if `.ai-workspace/` exists from a previous run
+2. If it exists, archive it to `.ai-workspace-archive/{timestamp}/` using `mv` (safer than `rm` on Windows)
+3. Create a fresh `.ai-workspace/` directory for the new run
+4. Log the archive action so the user knows where old artifacts went
+
+**Files to modify:**
+- `src/orchestrator.ts` -- add workspace cleanup at pipeline start, before NORMALIZE stage
+
+**ACs:**
+- Previous `.ai-workspace/` is moved to `.ai-workspace-archive/{ISO-timestamp}/` before new run starts
+- Fresh `.ai-workspace/` directory is created for the new pipeline run
+- Log message indicates where old workspace was archived
+- No error if `.ai-workspace/` doesn't exist (first run)
+- No error if `.ai-workspace-archive/` doesn't exist (auto-created)
+
+**Effort:** Small (< 0.5 day)
+
+**Depends on:** Nothing (can start immediately)
+
+---
+
 ## Execution Plan
 
 ```
+Pre-R1:
+  Baseline run on test PRD                -- 0.5 day (save outputs to baselines/pre-r1/)
+
 Week 1:
   [parallel] Story 4 (few-shot skepticism) -- 0.5 day
   [parallel] Story 5 (merge compliance)    -- 1-2 days
   [parallel] Story 6 (timeout + velocity)  -- 1 day
+  [parallel] Story 7 (workspace cleanup)   -- 0.5 day
   [parallel] Story 1 (MCP Phase 1)         -- starts, takes 2-3 days
 
 Week 2:
@@ -255,12 +313,14 @@ Week 3 (buffer):
 
 All must pass before R1 is considered done:
 
+- [ ] Baseline: pre-R1 pipeline outputs saved to `../hive-mind-design/baselines/pre-r1/`
 - [ ] MCP Phase 1: agents use MCP servers from `.hivemindrc.json`
 - [ ] WebSearch: research agent searches web during SPEC research
 - [ ] Context7: research agent fetches live library docs
 - [ ] Few-shot skepticism: critic prompts include skeptical examples
 - [ ] Compliance merged: no separate compliance stage, criteria are ECs
 - [ ] Safeguards: dynamic timeouts (2hr pre-execute, rolling-avg execute, 48hr cap), cost velocity warning
+- [ ] Workspace cleanup: old `.ai-workspace/` archived before new pipeline run
 - [ ] Regression: `npm run test` passes, `npm run build` succeeds
 - [ ] Validation: full pipeline run on test PRD produces scorecard >= baseline
 

--- a/docs/harness-roadmap/roadmap-releases.md
+++ b/docs/harness-roadmap/roadmap-releases.md
@@ -26,6 +26,7 @@
 | 4 | GAN few-shot skepticism (prompt change) | P3 | Small | P3 ss3.4 |
 | 5 | Merge compliance into VERIFY GAN loop | P3 | Small | P3 ss3.1 |
 | 6 | Pipeline timeout + cost velocity alert | P6 | Small | P6 ss6.3 |
+| 7 | Clear old .ai-workspace before new run | P6 | Small | -- |
 
 **Why first:** MCP unblocks everything. The rest are small/medium effort, high impact, zero architecture changes.
 
@@ -35,6 +36,7 @@
 - Compliance stage removed, criteria merged into VERIFY ECs
 - Critic prompts include few-shot skepticism examples
 - Pipeline has dynamic timeouts (2hr pre-execute, rolling-average during execute, 48hr hard cap) and 2x budget velocity warning
+- Old .ai-workspace archived before new pipeline run
 
 **Detailed plan:** [roadmap-release-1.md](roadmap-release-1.md)
 
@@ -126,6 +128,7 @@
 6. **Items can move:** If an R3 item becomes urgent, pull it into R2. If an R1 item is blocked, push to R2
 7. **Retrospective:** After each release, add a retro section to the release plan doc
 8. **Validation:** After each release, run a full pipeline on a test PRD and compare scorecard against baseline
+9. **Simple scales better:** Use simple algorithms and data structures. Fancy algorithms are slow when N is small -- and N is usually small. Only optimize when profiling proves a bottleneck.
 
 ## Deferred (v2+)
 Items explicitly deferred beyond R4:


### PR DESCRIPTION
## Summary
- Add pre-R1 baseline prerequisite (run pipeline, save outputs for comparison)
- Add Design Principle #3: simple scales better than complex (cross-release)
- Add Story 7: clear old .ai-workspace before new pipeline run
- Add 4 backlog items: 3-tier memory, cost breakdown by model, dashboard from normalize, stages-as-skills eval
- Update existing skills evaluation backlog item with Normalize/Spec/Plan complexity analysis

## Test plan
- [ ] roadmap-release-1.md has Pre-R1 Baseline section, Story 7, simplicity principle, updated exit criteria
- [ ] roadmap-releases.md R1 table has Story 7, How to Use has simplicity principle
- [ ] roadmap-backlog.md has 5 items (1 updated + 4 new)