### PR TITLE
fix: prevent dashboard from opening multiple browser tabs

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { join, resolve, sep, dirname } from "node:path";
 import { readFile, readdir } from "node:fs/promises";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, unlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { PipelineDirs } from "../types/pipeline-dirs.js";
 import type { HiveMindConfig } from "../config/schema.js";
@@ -2114,6 +2114,16 @@ export async function startDashboard(
 
   const DEFAULT_PORT = 4040;
   const MAX_PORT_ATTEMPTS = 10;
+  const portFilePath = join(workingDir, ".dashboard-port");
+
+  function writeDashboardPort(boundPort: number): void {
+    try { writeFileSync(portFilePath, String(boundPort)); } catch { /* non-fatal */ }
+  }
+
+  function shouldOpenBrowser(): boolean {
+    // Only open browser if no port file exists (first dashboard start this run)
+    return !existsSync(portFilePath);
+  }
 
   function tryListen(port: number, attempt: number): Promise<DashboardHandle> {
     return new Promise<DashboardHandle>((resolvePromise, rejectPromise) => {
@@ -2132,12 +2142,16 @@ export async function startDashboard(
         const boundPort = typeof address === "object" && address ? address.port : port;
         const url = `http://localhost:${boundPort}`;
 
-        openBrowser(url);
+        const wantBrowser = shouldOpenBrowser();
+        writeDashboardPort(boundPort);
+        if (wantBrowser) openBrowser(url);
+        else console.log(`Dashboard: ${url}`);
 
         resolvePromise({
           stop: () => {
             clearInterval(pollTimer);
             server.close();
+            try { unlinkSync(portFilePath); } catch { /* non-fatal */ }
           },
           url,
           signalShutdown: (shutdownAt: number) => {
@@ -2159,9 +2173,12 @@ export async function startDashboard(
         const address = server.address();
         const boundPort = typeof address === "object" && address ? address.port : portOverride;
         const url = `http://localhost:${boundPort}`;
-        openBrowser(url);
+        const wantBrowser = shouldOpenBrowser();
+        writeDashboardPort(boundPort);
+        if (wantBrowser) openBrowser(url);
+        else console.log(`Dashboard: ${url}`);
         resolvePromise({
-          stop: () => { clearInterval(pollTimer); server.close(); },
+          stop: () => { clearInterval(pollTimer); server.close(); try { unlinkSync(portFilePath); } catch { /* non-fatal */ } },
           url,
           signalShutdown: (shutdownAt: number) => { cached.shutdownAt = shutdownAt; },
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { runPipeline, resumeFromCheckpoint, runBugFixPipeline } from "./orchestr
 import { loadConfig, resolvePipelineDirs } from "./config/loader.js";
 import { HiveMindError } from "./utils/errors.js";
 import { join } from "node:path";
-import { realpathSync } from "node:fs";
+import { realpathSync, existsSync, readFileSync } from "node:fs";
 import { approveCheckpoint, rejectCheckpoint } from "./state/checkpoint-ops.js";
 import { startDashboard } from "./dashboard/server.js";
 import type { DashboardHandle } from "./dashboard/server.js";
@@ -111,8 +111,13 @@ export function parseArgs(argv: string[]): ParsedCommand {
   }
 }
 
-async function isDashboardRunning(port: number): Promise<boolean> {
+async function isDashboardRunning(workingDir: string): Promise<boolean> {
   try {
+    const portFilePath = join(workingDir, ".dashboard-port");
+    if (!existsSync(portFilePath)) return false;
+    const port = parseInt(readFileSync(portFilePath, "utf-8").trim(), 10);
+    if (isNaN(port)) return false;
+
     const { request } = await import("node:http");
     return new Promise((resolve) => {
       const req = request({ hostname: "localhost", port, path: "/api/status", method: "GET", timeout: 1000 }, (res) => {
@@ -138,7 +143,7 @@ export async function main(): Promise<void> {
   const wantsDashboard = dashboardCommands.has(parsed.command) && !("noDashboard" in parsed && parsed.noDashboard);
   let dashboardHandle: DashboardHandle | null = null;
   if (wantsDashboard) {
-    const dashboardAlive = await isDashboardRunning(4040);
+    const dashboardAlive = await isDashboardRunning(dirs.workingDir);
     if (dashboardAlive) {
       // Existing dashboard is serving the same working directory — skip
     } else {


### PR DESCRIPTION
## Summary
- Dashboard wrote bound port to `.dashboard-port` file so `isDashboardRunning()` checks the actual port instead of hardcoded 4040
- `openBrowser()` now only fires on first dashboard start per run (port file acts as "already opened" flag)
- Port file cleaned up on `handle.stop()`

Closes #149

## Root Cause
Two bugs interacted: `isDashboardRunning()` only checked port 4040, but port-retry logic could bind to 4041-4049. Each CLI command started a new server on the next port and opened a new browser tab. In a typical pipeline run this produced 5-7+ tabs.

## Test plan
- [x] `npx tsc --noEmit` passes (zero new errors)
- [x] `npm test` passes (638/638 tests, 75 files)
- [ ] Run `hive-mind start --prd <path>` then `hive-mind approve` — verify only 1 browser tab opens
- [ ] Kill dashboard process, run `hive-mind approve` — verify dashboard restarts on correct port without opening new tab