### PR TITLE
fix: address PR #153 code review comments

### DIFF
--- a/src/agents/model-map.ts
+++ b/src/agents/model-map.ts
@@ -1,8 +1,7 @@
 import type { AgentType, ModelTier } from "../types/agents.js";
 
-export { AGENT_MODEL_MAP } from "./registry.js";
-
 import { AGENT_MODEL_MAP } from "./registry.js";
+export { AGENT_MODEL_MAP };
 
 export function getModelForAgent(agentType: AgentType): ModelTier {
   return AGENT_MODEL_MAP[agentType];

--- a/src/agents/prompts.ts
+++ b/src/agents/prompts.ts
@@ -26,8 +26,7 @@ const JSON_OUTPUT_AGENTS: Set<AgentType> = new Set([
   "planner", "decomposer",
 ]);
 
-// AGENT_JOBS and AGENT_RULES are now derived from the central AGENT_REGISTRY.
-// Re-exported here for backward compatibility — see ./registry.ts for the source of truth.
+// AGENT_JOBS and AGENT_RULES are now in registry.ts; imported here for local use.
 
 export const ROLE_REPORT_MAPPING: Partial<Record<AgentType, AgentType[]>> = {
   "implementer": ["architect", "security", "analyst"],

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -342,7 +342,7 @@ export const AGENT_REGISTRY: Record<AgentType, AgentRegistryEntry> = {
   },
   "diagnostician-bug": {
     modelTier: "opus",
-    tools: [...READ_ONLY_TOOLS, "Write"],
+    tools: OUTPUT_TOOLS,
     job: "Read bug report + codebase, perform root cause analysis, produce diagnosis-report-attempt-N.md with Root Cause, Affected Files, Recommended Fix, and Confidence sections",
     rules: [
       "ROOT-CAUSE: Identify the actual root cause using Glob, Grep, and Read to search the codebase. Reference specific file:line locations.",


### PR DESCRIPTION
## Summary
Follow-up fixes for code review comments on #153:

1. **model-map.ts**: Collapse duplicate `export { X } from` + `import { X } from` into idiomatic `import` + named `export`
2. **prompts.ts**: Fix misleading comment — AGENT_JOBS/AGENT_RULES were never exported from this file
3. **registry.ts**: Use `OUTPUT_TOOLS` constant for `diagnostician-bug` instead of inlined spread

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (638/638)