### PR TITLE
fix: reuse previous dashboard port to avoid new browser tabs

### DIFF
--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -2185,5 +2185,15 @@ export async function startDashboard(
       });
     });
   }
-  return tryListen(DEFAULT_PORT, 1);
+
+  // If a previous dashboard wrote a port file but is now dead, try that port
+  // first so we reuse the same port and avoid opening a new browser tab.
+  let preferredPort = DEFAULT_PORT;
+  if (existsSync(portFilePath)) {
+    const prev = parseInt(readFileSync(portFilePath, "utf-8").trim(), 10);
+    if (!isNaN(prev) && prev >= DEFAULT_PORT && prev < DEFAULT_PORT + MAX_PORT_ATTEMPTS) {
+      preferredPort = prev;
+    }
+  }
+  return tryListen(preferredPort, 1);
 }


### PR DESCRIPTION
## Summary
- When each CLI command spawns a new dashboard server, the previous port may still be in TIME_WAIT, causing the server to climb ports (4040 → 4041 → 4042) and open new browser tabs each time.
- This fix reads the previous port from `.dashboard-port` and tries it first instead of always starting from `DEFAULT_PORT`, keeping the browser tab stable across CLI invocations.

## Test plan
- [ ] Run `hive-mind start` — dashboard opens on port 4040
- [ ] Run `hive-mind approve` — dashboard reuses port 4040 (no new tab)
- [ ] Delete `.dashboard-port` file — falls back to DEFAULT_PORT scan
- [ ] Corrupt `.dashboard-port` with invalid content — falls back to DEFAULT_PORT scan