### PR TITLE
fix: skip duplicate dashboard when one is already running

### DIFF
--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // Mock all heavy dependencies to isolate dashboard lifecycle tests
 vi.mock("../dashboard/server.js", () => ({
   startDashboard: vi.fn(),
+  isDashboardRunning: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock("../utils/file-io.js", () => ({

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -2197,3 +2197,26 @@ export async function startDashboard(
   }
   return tryListen(preferredPort, 1);
 }
+
+/** Check if a dashboard is already running for the given working directory. */
+export async function isDashboardRunning(workingDir: string): Promise<boolean> {
+  try {
+    const portFile = join(workingDir, ".dashboard-port");
+    if (!existsSync(portFile)) return false;
+    const port = parseInt(readFileSync(portFile, "utf-8").trim(), 10);
+    if (isNaN(port)) return false;
+
+    const { request } = await import("node:http");
+    return new Promise((resolve) => {
+      const req = request({ hostname: "localhost", port, path: "/api/status", method: "GET", timeout: 1000 }, (res) => {
+        res.resume();
+        resolve(res.statusCode === 200);
+      });
+      req.on("error", () => resolve(false));
+      req.on("timeout", () => { req.destroy(); resolve(false); });
+      req.end();
+    });
+  } catch {
+    return false;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { HiveMindError } from "./utils/errors.js";
 import { join } from "node:path";
 import { realpathSync, existsSync, readFileSync } from "node:fs";
 import { approveCheckpoint, rejectCheckpoint } from "./state/checkpoint-ops.js";
-import { startDashboard } from "./dashboard/server.js";
+import { startDashboard, isDashboardRunning } from "./dashboard/server.js";
 import type { DashboardHandle } from "./dashboard/server.js";
 
 export type ParsedCommand =
@@ -108,28 +108,6 @@ export function parseArgs(argv: string[]): ParsedCommand {
     }
     default:
       throw new HiveMindError(`Unknown command '${cmd}'. Run 'hive-mind help' for available commands.`);
-  }
-}
-
-async function isDashboardRunning(workingDir: string): Promise<boolean> {
-  try {
-    const portFilePath = join(workingDir, ".dashboard-port");
-    if (!existsSync(portFilePath)) return false;
-    const port = parseInt(readFileSync(portFilePath, "utf-8").trim(), 10);
-    if (isNaN(port)) return false;
-
-    const { request } = await import("node:http");
-    return new Promise((resolve) => {
-      const req = request({ hostname: "localhost", port, path: "/api/status", method: "GET", timeout: 1000 }, (res) => {
-        res.resume();
-        resolve(res.statusCode === 200);
-      });
-      req.on("error", () => resolve(false));
-      req.on("timeout", () => { req.destroy(); resolve(false); });
-      req.end();
-    });
-  } catch {
-    return false;
   }
 }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -63,7 +63,7 @@ import { writeFileAtomic } from "./utils/file-io.js";
 import { spawnAgentWithRetry } from "./agents/spawner.js";
 import { getAgentRules } from "./agents/prompts.js";
 import { runScorecard } from "./stages/scorecard.js";
-import { startDashboard } from "./dashboard/server.js";
+import { startDashboard, isDashboardRunning } from "./dashboard/server.js";
 
 function printTimingSummary(tracker: CostTracker): void {
   const timing = tracker.getTimingSummary();
@@ -144,11 +144,14 @@ export async function runPipeline(
   // Dashboard lifecycle — non-fatal observer (DESIGN-01)
   let dashboardHandle: { stop: () => void; url: string; signalShutdown: (shutdownAt: number) => void } | null = null;
   if (!options?.noDashboard) {
-    try {
-      dashboardHandle = await startDashboard(dirs, config);
-    } catch (err) {
-      process.stderr.write(`Dashboard server error: ${err instanceof Error ? err.message : String(err)}\n`);
-      dashboardHandle = null;
+    const alreadyRunning = await isDashboardRunning(dirs.workingDir);
+    if (!alreadyRunning) {
+      try {
+        dashboardHandle = await startDashboard(dirs, config);
+      } catch (err) {
+        process.stderr.write(`Dashboard server error: ${err instanceof Error ? err.message : String(err)}\n`);
+        dashboardHandle = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Each CLI command (`start`, `approve`, `reject`) spawned its own dashboard server, resulting in duplicate servers on different ports (e.g., 4040 and 4041)
- Root cause: `orchestrator.ts` unconditionally called `startDashboard()` without checking if one was already running, while `index.ts` had the check
- Fix: moved `isDashboardRunning()` to `dashboard/server.ts` as a shared export, added the health-check guard in `orchestrator.ts`

## Test plan
- [ ] `npx tsc --noEmit` exits 0
- [ ] `npm test` — 638 tests pass
- [ ] Run `hive-mind start` then `hive-mind approve` — only one dashboard port responds
- [ ] Cold start (no prior dashboard) — dashboard opens normally