### PR TITLE
fix: persist recovery checkpoint to prevent progress loss on stage crash

### DIFF
--- a/src/__tests__/cli-start-prd.test.ts
+++ b/src/__tests__/cli-start-prd.test.ts
@@ -5,7 +5,7 @@ import { HiveMindError } from "../utils/errors.js";
 describe("CLI start command", () => {
   it("parses start --prd correctly", () => {
     const result = parseArgs(["node", "cli", "start", "--prd", "./test.md"]);
-    expect(result).toEqual({ command: "start", prdPath: "./test.md", silent: false, budget: undefined, skipBaseline: false, stopAfterPlan: false, skipNormalize: false, greenfield: false, noDashboard: false });
+    expect(result).toEqual({ command: "start", prdPath: "./test.md", silent: false, budget: undefined, skipBaseline: false, stopAfterPlan: false, skipNormalize: false, greenfield: false, noDashboard: false, force: false });
   });
 
   it("parses start --prd --skip-normalize correctly", () => {

--- a/src/__tests__/orchestrator/crash-recovery.test.ts
+++ b/src/__tests__/orchestrator/crash-recovery.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from "vitest";
+import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getDefaultConfig } from "../../config/loader.js";
+import type { PipelineDirs } from "../../types/pipeline-dirs.js";
+import type { Checkpoint } from "../../types/checkpoint.js";
+
+// Mock the agent spawner — plan-stage agents will throw to simulate crash
+vi.mock("../../agents/spawner.js", () => ({
+  spawnAgentWithRetry: vi.fn(async (config: { outputFile: string; type: string }) => {
+    const { writeFileSync: wf, mkdirSync: md } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    md(dirname(config.outputFile), { recursive: true });
+    wf(config.outputFile, `# Mock output for ${config.type}`);
+    return { success: true, outputFile: config.outputFile, costUsd: 0, durationMs: 100 };
+  }),
+  spawnAgent: vi.fn(async () => ({ success: true, outputFile: "" })),
+  spawnAgentsParallel: vi.fn(async (configs: Array<{ outputFile: string; type: string }>) => {
+    const { writeFileSync: wf, mkdirSync: md } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    return configs.map((c) => {
+      md(dirname(c.outputFile), { recursive: true });
+      wf(c.outputFile, `# Mock output for ${c.type}`);
+      return { success: true, outputFile: c.outputFile, costUsd: 0, durationMs: 100 };
+    });
+  }),
+}));
+
+// Mock baseline check
+vi.mock("../../stages/baseline-check.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../stages/baseline-check.js")>();
+  return {
+    ...original,
+    runBaselineCheck: vi.fn(async () => ({ passed: true, buildOutput: "", testOutput: "" })),
+  };
+});
+
+// Mock plan stage to throw (simulates API limit crash)
+vi.mock("../../stages/plan-stage.js", () => ({
+  runPlanStage: vi.fn(async () => {
+    throw new Error("Planner failed: API usage limit reached");
+  }),
+}));
+
+const config = getDefaultConfig();
+
+function makeTestDir(name: string): { testDir: string; dirs: PipelineDirs; cleanup: () => void } {
+  const testDir = join(process.cwd(), `.test-crash-recovery-${name}`);
+  mkdirSync(testDir, { recursive: true });
+  const dirs: PipelineDirs = { workingDir: testDir, knowledgeDir: testDir, labDir: testDir };
+  return { testDir, dirs, cleanup: () => rmSync(testDir, { recursive: true, force: true }) };
+}
+
+function writeManagerLog(dir: string): void {
+  writeFileSync(
+    join(dir, "manager-log.jsonl"),
+    JSON.stringify({
+      timestamp: "2026-03-30T00:00:00Z",
+      cycle: 0,
+      storyId: null,
+      action: "PIPELINE_START",
+      reason: null,
+      prdPath: "./PRD.md",
+      stopAfterPlan: false,
+    }) + "\n",
+  );
+}
+
+describe("crash recovery checkpoints", () => {
+  it("recovery checkpoint survives when PLAN crashes after approve-spec", async () => {
+    const { resumeFromCheckpoint } = await import("../../orchestrator.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { testDir, dirs, cleanup } = makeTestDir("spec-crash");
+    try {
+      // Set up: SPEC was approved, artifacts exist
+      writeFileSync(join(testDir, ".checkpoint"), JSON.stringify({ awaiting: "approve-spec" }));
+      writeManagerLog(testDir);
+      mkdirSync(join(testDir, "spec"), { recursive: true });
+      writeFileSync(join(testDir, "spec", "SPEC-v1.0.md"), "# Test SPEC");
+
+      const checkpoint: Checkpoint = {
+        awaiting: "approve-spec",
+        message: "test",
+        timestamp: "2026-03-30T00:00:00Z",
+        feedback: null,
+      };
+
+      // PLAN stage will throw (mocked)
+      await expect(resumeFromCheckpoint(checkpoint, dirs, config)).rejects.toThrow();
+
+      // Recovery checkpoint should survive
+      expect(existsSync(join(testDir, ".checkpoint"))).toBe(true);
+      const recovered = JSON.parse(readFileSync(join(testDir, ".checkpoint"), "utf-8"));
+      expect(recovered.awaiting).toBe("approve-spec");
+      expect(recovered.message).toContain("recovery checkpoint");
+    } finally {
+      consoleSpy.mockRestore();
+      cleanup();
+    }
+  });
+
+  it("recovery checkpoint written for approve-normalize before SPEC runs", async () => {
+    const { resumeFromCheckpoint } = await import("../../orchestrator.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { testDir, dirs, cleanup } = makeTestDir("normalize-recovery");
+    try {
+      writeFileSync(join(testDir, ".checkpoint"), JSON.stringify({ awaiting: "approve-normalize" }));
+      writeManagerLog(testDir);
+      mkdirSync(join(testDir, "normalize"), { recursive: true });
+      writeFileSync(join(testDir, "normalize", "normalized-prd.md"), "# Normalized PRD\n\nContent here.");
+
+      const checkpoint: Checkpoint = {
+        awaiting: "approve-normalize",
+        message: "test",
+        timestamp: "2026-03-30T00:00:00Z",
+        feedback: null,
+      };
+
+      // SPEC stage will run and complete (mocked agents produce output).
+      // After SPEC completes, writeCheckpoint(approve-spec) overwrites recovery.
+      await resumeFromCheckpoint(checkpoint, dirs, config);
+
+      // Final checkpoint should be approve-spec (recovery was overwritten by SPEC completion)
+      expect(existsSync(join(testDir, ".checkpoint"))).toBe(true);
+      const final = JSON.parse(readFileSync(join(testDir, ".checkpoint"), "utf-8"));
+      expect(final.awaiting).toBe("approve-spec");
+    } finally {
+      consoleSpy.mockRestore();
+      cleanup();
+    }
+  });
+});
+
+describe("start command checkpoint guard", () => {
+  it("start throws when checkpoint exists and --force not set", async () => {
+    const { runPipeline } = await import("../../orchestrator.js");
+
+    const { testDir, dirs, cleanup } = makeTestDir("start-guard");
+    try {
+      mkdirSync(join(testDir, "spec"), { recursive: true });
+      writeFileSync(join(testDir, "spec", "SPEC-v1.0.md"), "# spec");
+      writeFileSync(join(testDir, ".checkpoint"), JSON.stringify({ awaiting: "approve-spec" }));
+
+      const prdPath = join(testDir, "PRD.md");
+      writeFileSync(prdPath, "# Test PRD");
+
+      await expect(runPipeline(prdPath, dirs, config)).rejects.toThrow(/Active checkpoint found/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("start proceeds when checkpoint exists and --force is set", async () => {
+    const { runPipeline } = await import("../../orchestrator.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // PRD must live OUTSIDE working dir so cleanup doesn't delete it
+    const testDir = join(process.cwd(), ".test-crash-recovery-start-force");
+    mkdirSync(testDir, { recursive: true });
+    const hmDir = join(testDir, ".hive-mind");
+    mkdirSync(hmDir, { recursive: true });
+    const dirs: PipelineDirs = { workingDir: hmDir, knowledgeDir: hmDir, labDir: hmDir };
+
+    try {
+      mkdirSync(join(hmDir, "spec"), { recursive: true });
+      writeFileSync(join(hmDir, "spec", "SPEC-v1.0.md"), "# spec");
+      writeFileSync(join(hmDir, ".checkpoint"), JSON.stringify({ awaiting: "approve-spec" }));
+
+      const prdPath = join(testDir, "PRD.md");
+      writeFileSync(prdPath, "# Test PRD\n\n## Overview\nThis is a test PRD with enough content.\n\n## Goals\n- Goal 1\n- Goal 2\n");
+
+      // Should not throw — force overrides the guard
+      // (will proceed to SPEC and eventually write a new checkpoint)
+      await expect(runPipeline(prdPath, dirs, config, { skipNormalize: true, force: true })).resolves.not.toThrow();
+    } finally {
+      consoleSpy.mockRestore();
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { startDashboard, isDashboardRunning } from "./dashboard/server.js";
 import type { DashboardHandle } from "./dashboard/server.js";
 
 export type ParsedCommand =
-  | { command: "start"; prdPath: string; silent?: boolean; budget?: number; skipBaseline?: boolean; stopAfterPlan?: boolean; skipNormalize?: boolean; greenfield?: boolean; noDashboard?: boolean }
+  | { command: "start"; prdPath: string; silent?: boolean; budget?: number; skipBaseline?: boolean; stopAfterPlan?: boolean; skipNormalize?: boolean; greenfield?: boolean; noDashboard?: boolean; force?: boolean }
   | { command: "bug"; reportPath: string; silent?: boolean; skipBaseline?: boolean }
   | { command: "approve"; silent?: boolean; skipBaseline?: boolean }
   | { command: "reject"; feedback: string; silent?: boolean }
@@ -64,7 +64,8 @@ export function parseArgs(argv: string[]): ParsedCommand {
       const skipNormalize = args.includes("--skip-normalize");
       const greenfield = args.includes("--greenfield");
       const noDashboard = args.includes("--no-dashboard");
-      return { command: "start", prdPath: args[prdIdx + 1], silent, budget, skipBaseline, stopAfterPlan, skipNormalize, greenfield, noDashboard };
+      const force = args.includes("--force");
+      return { command: "start", prdPath: args[prdIdx + 1], silent, budget, skipBaseline, stopAfterPlan, skipNormalize, greenfield, noDashboard, force };
     }
     case "bug": {
       const reportIdx = args.indexOf("--report");
@@ -154,7 +155,7 @@ export async function main(): Promise<void> {
       if (claudeCheck.exitCode !== 0) {
         throw new HiveMindError("claude CLI not found on PATH");
       }
-      await runPipeline(parsed.prdPath, dirs, config, { silent: parsed.silent, budget: parsed.budget, skipBaseline: parsed.skipBaseline, stopAfterPlan: parsed.stopAfterPlan, skipNormalize: parsed.skipNormalize, greenfield: parsed.greenfield, noDashboard: true });
+      await runPipeline(parsed.prdPath, dirs, config, { silent: parsed.silent, budget: parsed.budget, skipBaseline: parsed.skipBaseline, stopAfterPlan: parsed.stopAfterPlan, skipNormalize: parsed.skipNormalize, greenfield: parsed.greenfield, noDashboard: true, force: parsed.force });
       break;
     }
     case "bug": {
@@ -227,9 +228,21 @@ export async function main(): Promise<void> {
       break;
     }
     case "resume": {
+      // Check for active checkpoint first (crash recovery — pre-PLAN stages)
+      const resumeCheckpoint = readCheckpointFile(dirs);
+      if (resumeCheckpoint) {
+        console.log(`Active checkpoint found (${resumeCheckpoint.awaiting}). Resuming from checkpoint...`);
+        const resumeApproveResult = await approveCheckpoint(dirs.workingDir);
+        if (!resumeApproveResult.success) {
+          throw new HiveMindError(resumeApproveResult.error ?? "Checkpoint approval failed");
+        }
+        await resumeFromCheckpoint(resumeCheckpoint, dirs, config, { silent: parsed.silent });
+        break;
+      }
+
       const planPath = join(dirs.workingDir, "plans/execution-plan.json");
       if (!fileExists(planPath)) {
-        throw new HiveMindError("No execution plan found. Run 'start' and 'approve' first.");
+        throw new HiveMindError("No execution plan or checkpoint found. Run 'start' first.");
       }
       const { loadExecutionPlan, updateStoryStatus, saveExecutionPlan, resetAllFailedStories } = await import("./state/execution-plan.js");
       let plan = loadExecutionPlan(planPath);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -115,10 +115,21 @@ export async function runPipeline(
   prdPath: string,
   dirs: PipelineDirs,
   config: HiveMindConfig,
-  options?: { silent?: boolean; budget?: number; skipBaseline?: boolean; stopAfterPlan?: boolean; skipNormalize?: boolean; greenfield?: boolean; noDashboard?: boolean },
+  options?: { silent?: boolean; budget?: number; skipBaseline?: boolean; stopAfterPlan?: boolean; skipNormalize?: boolean; greenfield?: boolean; noDashboard?: boolean; force?: boolean },
 ): Promise<void> {
   if (!fileExists(prdPath)) {
     throw new HiveMindError(`PRD file not found: ${prdPath}`);
+  }
+
+  // Guard: don't wipe working directory if an active checkpoint exists (crash recovery)
+  if (existsSync(dirs.workingDir)) {
+    const checkpointPath = join(dirs.workingDir, ".checkpoint");
+    if (existsSync(checkpointPath) && !options?.force) {
+      throw new HiveMindError(
+        "Active checkpoint found — pipeline has partial progress. " +
+        "Run 'hive-mind approve' to resume, or 'hive-mind start --force --prd <path>' to discard and restart.",
+      );
+    }
   }
 
   // Clean stale working directory from previous runs
@@ -250,6 +261,7 @@ async function runSpecThenCheckpoint(
       printTimingSummary(tracker);
       writeTimingReport(tracker, dirs.workingDir);
     }
+    deleteCheckpoint(dirs.workingDir); // Clean up recovery checkpoint — clean exit
     return;
   }
 
@@ -311,6 +323,14 @@ export async function resumeFromCheckpoint(
     case "approve-normalize": {
       deleteCheckpoint(dirs.workingDir);
 
+      // Recovery checkpoint — survives crash so user can retry via approve/resume
+      writeCheckpoint(dirs.workingDir, {
+        awaiting: "approve-normalize",
+        message: "NORMALIZE approved — SPEC stage in progress (recovery checkpoint)",
+        timestamp: isoTimestamp(),
+        feedback: null,
+      });
+
       const normalizedPrd = join(dirs.workingDir, "normalize", "normalized-prd.md");
       const normalizedContent = readFileSafe(normalizedPrd);
       if (normalizedContent === null) {
@@ -348,6 +368,15 @@ export async function resumeFromCheckpoint(
     }
     case "approve-spec": {
       deleteCheckpoint(dirs.workingDir);
+
+      // Recovery checkpoint — survives crash so user can retry via approve/resume
+      writeCheckpoint(dirs.workingDir, {
+        awaiting: "approve-spec",
+        message: "SPEC approved — PLAN stage in progress (recovery checkpoint)",
+        timestamp: isoTimestamp(),
+        feedback: null,
+      });
+
       const startDataSpec = getPipelineStartData(dirs.workingDir);
 
       if (feedback) {
@@ -436,6 +465,7 @@ export async function resumeFromCheckpoint(
         if (config.liveReport) updateLiveReport(dirs.workingDir, "COMPLETE", "Pipeline stopped after PLAN");
         printTimingSummary(specTracker);
         writeTimingReport(specTracker, dirs.workingDir);
+        deleteCheckpoint(dirs.workingDir); // Clean up recovery checkpoint — clean exit
         break;
       }
 
@@ -460,6 +490,14 @@ export async function resumeFromCheckpoint(
         await runBaselineCheck(config);
       }
       deleteCheckpoint(dirs.workingDir);
+
+      // Recovery checkpoint — survives crash so user can retry via approve/resume
+      writeCheckpoint(dirs.workingDir, {
+        awaiting: "approve-plan",
+        message: "PLAN approved — EXECUTE stage in progress (recovery checkpoint)",
+        timestamp: isoTimestamp(),
+        feedback: null,
+      });
 
       const execCostLogPath = join(dirs.workingDir, "cost-log.jsonl");
       const tracker = CostTracker.loadFromDisk(execCostLogPath, startDataPlan.budget);
@@ -504,6 +542,15 @@ export async function resumeFromCheckpoint(
     }
     case "approve-usage-limit": {
       deleteCheckpoint(dirs.workingDir);
+
+      // Recovery checkpoint — survives crash so user can retry via approve/resume
+      writeCheckpoint(dirs.workingDir, {
+        awaiting: "approve-usage-limit",
+        message: "Usage limit approved — resuming EXECUTE (recovery checkpoint)",
+        timestamp: isoTimestamp(),
+        feedback: null,
+      });
+
       usageLimitTracker.reset();
 
       const startDataLimit = getPipelineStartData(dirs.workingDir);
@@ -544,6 +591,14 @@ export async function resumeFromCheckpoint(
     case "approve-diagnosis": {
       deleteCheckpoint(dirs.workingDir);
 
+      // Recovery checkpoint — survives crash so user can retry via approve/resume
+      writeCheckpoint(dirs.workingDir, {
+        awaiting: "approve-diagnosis",
+        message: "Diagnosis approved — FIX stage in progress (recovery checkpoint)",
+        timestamp: isoTimestamp(),
+        feedback: null,
+      });
+
       const exitCode = await resumeBugFixPipeline(dirs, config, { silent });
       if (exitCode !== 0) {
         console.error("Bug fix pipeline failed.");
@@ -554,6 +609,14 @@ export async function resumeFromCheckpoint(
     }
     case "approve-integration": {
       deleteCheckpoint(dirs.workingDir);
+
+      // Recovery checkpoint — survives crash so user can retry via approve/resume
+      writeCheckpoint(dirs.workingDir, {
+        awaiting: "approve-integration",
+        message: "Integration approved — REPORT stage in progress (recovery checkpoint)",
+        timestamp: isoTimestamp(),
+        feedback: null,
+      });
 
       await writeReportAndCheckpoint(dirs, config, silent, "REPORT stage complete. Awaiting verification.");
       break;


### PR DESCRIPTION
## Summary

- Writes a recovery checkpoint before each stage transition in `resumeFromCheckpoint()`, so if a stage crashes (e.g., API usage limit), the user can `approve` or `resume` to retry instead of losing all prior work
- Guards `start` against wiping a working directory that has an active checkpoint; adds `--force` flag to override
- Enhances `resume` to detect active checkpoints and resume from them (not just from `execution-plan.json`)

Bug reported by bold-wolf during travel-watchdog baseline run: PLAN crashed twice from API limits after SPEC approval, losing ~37 min of NORMALIZE + SPEC work each time.

## Test plan

- [ ] `npx tsc --noEmit` passes (zero type errors)
- [ ] `npm test` passes (642/642 tests, including 4 new crash-recovery tests)
- [ ] Recovery checkpoint survives when PLAN crashes after approve-spec
- [ ] `start` throws when checkpoint exists without `--force`
- [ ] `start --force` proceeds despite existing checkpoint
- [ ] `resume` detects checkpoint and resumes from it