### PR TITLE
chore: gitignore old working dirs and remove unused script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ e2e/results/
 CLAUDE.md
 .claude/
 .hive-mind-working/
+.hive-mind-working-old-*/
 .hive-mind-lab/
 .ai-workspace/
 tmp/


### PR DESCRIPTION
## Summary
- Added `.hive-mind-working-old-*/` to `.gitignore` to prevent old working directories from being accidentally committed
- Deleted `check_5_files.sh` (unused diagnostic script, not referenced anywhere)

## Test plan
- [ ] `git status` no longer shows `.hive-mind-working-old-2026-03-23/` or `check_5_files.sh` as untracked