### PR TITLE
fix: scope tsc gate to story-owned files

### DIFF
--- a/src/__tests__/stages/execute-build.test.ts
+++ b/src/__tests__/stages/execute-build.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Story } from "../../types/execution-plan.js";
+import { BuildPipelineError } from "../../utils/errors.js";
+
+// Track tsc mock behavior — default: pass (no typescript dep detected)
+let tscMockError: Error | null = null;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: (...args: unknown[]) => {
+      const cmdArgs = args[1] as string[];
+      const cb = args[args.length - 1] as (err: Error | null, stdout: string, stderr: string) => void;
+      if (cmdArgs?.[0] === "tsc" && tscMockError) {
+        cb(tscMockError, "", "");
+        return;
+      }
+      // For non-tsc calls, use real execFile
+      return actual.execFile(...(args as Parameters<typeof actual.execFile>));
+    },
+  };
+});
 
 vi.mock("../../agents/spawner.js", () => ({
   spawnAgentWithRetry: vi.fn(async (config: { outputFile: string; type: string; cwd?: string }) => {
@@ -208,6 +229,52 @@ describe("execute-build", () => {
     } finally {
       cleanup();
       rmSync(extDir, { recursive: true, force: true });
+    }
+  });
+
+  it("TC7: tsc gate passes when all errors are in foreign files", async () => {
+    setup();
+    // Add package.json with typescript dep so tsc gate activates
+    writeFileSync(join(testDir, "package.json"), JSON.stringify({ devDependencies: { typescript: "^5.0.0" } }));
+    // Mock tsc to fail with errors only in files outside story scope
+    const foreignError = Object.assign(new Error("tsc failed"), {
+      stdout: "src/other.ts(3,5): error TS2304: Cannot find name 'X'.\nsrc/another.ts(1,1): error TS1005: ';' expected.",
+      stderr: "",
+      code: 2,
+    });
+    tscMockError = foreignError;
+    try {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      // Should NOT throw — foreign errors are ignored
+      await runBuild(testStory, dirs, config);
+      consoleSpy.mockRestore();
+      debugSpy.mockRestore();
+    } finally {
+      tscMockError = null;
+      cleanup();
+    }
+  });
+
+  it("TC8: tsc gate throws when errors are in owned files", async () => {
+    setup();
+    writeFileSync(join(testDir, "package.json"), JSON.stringify({ devDependencies: { typescript: "^5.0.0" } }));
+    // Mock tsc to fail with errors in story's owned file (src/test.ts)
+    const ownedError = Object.assign(new Error("tsc failed"), {
+      stdout: "src/test.ts(3,5): error TS2304: Cannot find name 'X'.",
+      stderr: "",
+      code: 2,
+    });
+    tscMockError = ownedError;
+    try {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await expect(runBuild(testStory, dirs, config)).rejects.toThrow(BuildPipelineError);
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    } finally {
+      tscMockError = null;
+      cleanup();
     }
   });
 });

--- a/src/__tests__/utils/tsc-error-filter.test.ts
+++ b/src/__tests__/utils/tsc-error-filter.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { filterTscErrorsByScope } from "../../utils/tsc-error-filter.js";
+
+describe("filterTscErrorsByScope", () => {
+  const targetDir = "/project";
+
+  it("TC1: all errors in scope — returned as owned", () => {
+    const tscOutput = [
+      "src/foo.ts(3,5): error TS2304: Cannot find name 'X'.",
+      "src/foo.ts(10,1): error TS1005: ';' expected.",
+    ].join("\n");
+
+    const result = filterTscErrorsByScope(tscOutput, ["src/foo.ts"], targetDir);
+    expect(result.ownedErrors).toHaveLength(2);
+    expect(result.foreignErrors).toHaveLength(0);
+  });
+
+  it("TC2: all errors outside scope — returned as foreign", () => {
+    const tscOutput = [
+      "src/bar.ts(3,5): error TS2304: Cannot find name 'X'.",
+      "src/baz.ts(7,2): error TS2339: Property 'x' does not exist.",
+    ].join("\n");
+
+    const result = filterTscErrorsByScope(tscOutput, ["src/foo.ts"], targetDir);
+    expect(result.ownedErrors).toHaveLength(0);
+    expect(result.foreignErrors).toHaveLength(2);
+  });
+
+  it("TC3: mixed errors — correctly partitioned", () => {
+    const tscOutput = [
+      "src/foo.ts(3,5): error TS2304: Cannot find name 'X'.",
+      "src/bar.ts(1,1): error TS2304: Cannot find name 'Y'.",
+      "src/foo.ts(10,1): error TS1005: ';' expected.",
+      "src/baz.ts(7,2): error TS2339: Property 'x' does not exist.",
+      "src/qux.ts(2,3): error TS2307: Cannot find module 'z'.",
+    ].join("\n");
+
+    const result = filterTscErrorsByScope(tscOutput, ["src/foo.ts"], targetDir);
+    expect(result.ownedErrors).toHaveLength(2);
+    expect(result.foreignErrors).toHaveLength(3);
+  });
+
+  it("TC4: Windows backslash paths — matched against forward-slash scope", () => {
+    const tscOutput = "src\\foo.ts(3,5): error TS2304: Cannot find name 'X'.";
+
+    const result = filterTscErrorsByScope(tscOutput, ["src/foo.ts"], targetDir);
+    expect(result.ownedErrors).toHaveLength(1);
+    expect(result.foreignErrors).toHaveLength(0);
+  });
+
+  it("TC5: empty scopeFiles — all errors foreign", () => {
+    const tscOutput = "src/foo.ts(3,5): error TS2304: Cannot find name 'X'.";
+
+    const result = filterTscErrorsByScope(tscOutput, [], targetDir);
+    expect(result.ownedErrors).toHaveLength(0);
+    expect(result.foreignErrors).toHaveLength(1);
+  });
+
+  it("TC6: no error lines — both arrays empty", () => {
+    const tscOutput = "Found 3 errors in 2 files.\n\n";
+
+    const result = filterTscErrorsByScope(tscOutput, ["src/foo.ts"], targetDir);
+    expect(result.ownedErrors).toHaveLength(0);
+    expect(result.foreignErrors).toHaveLength(0);
+  });
+});

--- a/src/stages/execute-build.ts
+++ b/src/stages/execute-build.ts
@@ -13,6 +13,7 @@ import type { HiveMindConfig } from "../config/schema.js";
 import type { CostTracker } from "../utils/cost-tracker.js";
 import type { PipelineDirs } from "../types/pipeline-dirs.js";
 import { join, resolve } from "node:path";
+import { filterTscErrorsByScope } from "../utils/tsc-error-filter.js";
 import { existsSync, readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -136,9 +137,26 @@ export async function runBuild(
       if (execErr.killed || execErr.signal) {
         console.debug(`[${story.id}] tsc gate skipped (timeout/signal): ${execErr.signal}`);
       } else {
-        const tscOutput = (execErr.stdout || execErr.stderr || "").slice(0, 2000);
-        console.warn(`[${story.id}] tsc --noEmit failed after BUILD:\n${tscOutput}`);
-        throw new BuildPipelineError("typecheck", `BUILD type-check gate failed:\n${tscOutput}`);
+        const tscOutput = (execErr.stdout || "") + "\n" + (execErr.stderr || "");
+        const { ownedErrors, foreignErrors } = filterTscErrorsByScope(
+          tscOutput,
+          effectiveSourceFilePaths,
+          targetDir,
+        );
+
+        if (foreignErrors.length > 0) {
+          console.debug(
+            `[${story.id}] tsc gate: ${foreignErrors.length} error(s) in files outside scope (ignored):\n${foreignErrors.slice(0, 5).join("\n")}${foreignErrors.length > 5 ? `\n... and ${foreignErrors.length - 5} more` : ""}`,
+          );
+        }
+
+        if (ownedErrors.length > 0) {
+          const truncated = ownedErrors.join("\n").slice(0, 2000);
+          console.warn(`[${story.id}] tsc --noEmit failed after BUILD (${ownedErrors.length} error(s) in scope):\n${truncated}`);
+          throw new BuildPipelineError("typecheck", `BUILD type-check gate failed:\n${truncated}`);
+        } else {
+          console.debug(`[${story.id}] tsc gate: all ${foreignErrors.length} error(s) are outside scope — passing`);
+        }
       }
     }
   } else if (existsSync(pkgJsonPath)) {

--- a/src/utils/tsc-error-filter.ts
+++ b/src/utils/tsc-error-filter.ts
@@ -1,0 +1,37 @@
+import { resolve, relative } from "node:path";
+
+const toSlash = (p: string): string => p.replace(/\\/g, "/");
+
+const TSC_ERROR_RE = /^(.+?)\(\d+,\d+\):\s*error\s+TS\d+:/;
+
+/**
+ * Parse tsc error output and partition errors by file ownership.
+ * Returns only errors whose file path is in `scopeFiles`; the rest are foreign.
+ */
+export function filterTscErrorsByScope(
+  tscOutput: string,
+  scopeFiles: string[],
+  targetDir: string,
+): { ownedErrors: string[]; foreignErrors: string[] } {
+  const normalizedScope = new Set(scopeFiles.map(toSlash));
+
+  const ownedErrors: string[] = [];
+  const foreignErrors: string[] = [];
+
+  for (const line of tscOutput.split("\n")) {
+    const match = line.match(TSC_ERROR_RE);
+    if (!match) continue;
+
+    const rawPath = match[1].trim();
+    const absPath = resolve(targetDir, rawPath);
+    const relPath = toSlash(relative(targetDir, absPath));
+
+    if (normalizedScope.has(relPath)) {
+      ownedErrors.push(line);
+    } else {
+      foreignErrors.push(line);
+    }
+  }
+
+  return { ownedErrors, foreignErrors };
+}


### PR DESCRIPTION
## Summary
- The BUILD tsc gate ran `tsc --noEmit` on the entire project, but each story implementer is FILE-SCOPE constrained to only its own `sourceFiles`. Foreign type errors caused correct stories to fail (1/18 pass rate in baseline run).
- Added `filterTscErrorsByScope()` utility that parses tsc output and partitions errors by file ownership. The gate now only fails for errors in the story's own files; foreign errors are logged at debug level.
- Bug reported by bold-wolf from travel-watchdog baseline run.

## Test plan
- [x] TC1-TC6: Unit tests for `filterTscErrorsByScope` (owned-only, foreign-only, mixed, Windows paths, empty scope, no error lines)
- [x] TC7: Integration test — gate passes when all tsc errors are in foreign files
- [x] TC8: Integration test — gate throws `BuildPipelineError` when errors are in owned files
- [x] TC9: `npx tsc --noEmit` passes
- [x] TC10: `npm test` passes (650/650)