### PR TITLE
fix: replace auto UI detection with user-choice checkpoint + EBUSY cleanup

### DIFF
--- a/src/__tests__/e2e/pipeline-smoke.test.ts
+++ b/src/__tests__/e2e/pipeline-smoke.test.ts
@@ -163,16 +163,23 @@ describe("pipeline smoke test (e2e)", () => {
     const logEntries = readLogEntries(hmDir);
     expect(logEntries.some((e) => e.action === "PIPELINE_START")).toBe(true);
 
-    // Step 2: Approve normalize → DESIGN auto-skips (no UI keywords) → checkpoint at approve-spec
+    // Step 2: Approve normalize → DESIGN writes approve-design-choice checkpoint
     await resumeFromCheckpoint(
       { awaiting: "approve-normalize", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
       dirs, config,
     );
 
     cp = readCheckpointFile(hmDir);
+    expect(cp?.awaiting).toBe("approve-design-choice");
+
+    // Step 2b: Approve design-choice (skip design) → flows to SPEC → checkpoint at approve-spec
+    await resumeFromCheckpoint(
+      { awaiting: "approve-design-choice", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
+      dirs, config,
+    );
+
+    cp = readCheckpointFile(hmDir);
     expect(cp?.awaiting).toBe("approve-spec");
-    const logEntries2 = readLogEntries(hmDir);
-    expect(logEntries2.some((e) => e.action === "DESIGN_SKIPPED")).toBe(true);
     expect(existsSync(join(hmDir, "spec"))).toBe(true);
     const logEntries2b = readLogEntries(hmDir);
     expect(logEntries2b.some((e) => e.action === "SPEC_COMPLETE")).toBe(true);
@@ -273,9 +280,18 @@ describe("pipeline smoke test (e2e)", () => {
     let cp = readCheckpointFile(hmDir);
     expect(cp?.awaiting).toBe("approve-normalize");
 
-    // Resume — DESIGN auto-skips (no UI keywords) → SPEC + PLAN run, stopAfterPlan honored → exits with no checkpoint
+    // Resume — DESIGN writes approve-design-choice checkpoint
     await resumeFromCheckpoint(
       { awaiting: "approve-normalize", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
+      dirs, config,
+    );
+
+    cp = readCheckpointFile(hmDir);
+    expect(cp?.awaiting).toBe("approve-design-choice");
+
+    // Approve design-choice (skip) → SPEC + PLAN run, stopAfterPlan honored → exits with no checkpoint
+    await resumeFromCheckpoint(
+      { awaiting: "approve-design-choice", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
       dirs, config,
     );
 

--- a/src/__tests__/orchestrator/crash-recovery.test.ts
+++ b/src/__tests__/orchestrator/crash-recovery.test.ts
@@ -120,13 +120,13 @@ describe("crash recovery checkpoints", () => {
         feedback: null,
       };
 
-      // DESIGN stage auto-skips (no UI keywords) → flows to SPEC checkpoint.
+      // DESIGN stage writes approve-design-choice checkpoint for user decision.
       await resumeFromCheckpoint(checkpoint, dirs, config);
 
-      // Final checkpoint should be approve-spec (DESIGN auto-skipped)
+      // Final checkpoint should be approve-design-choice (user decides whether to run design)
       expect(existsSync(join(testDir, ".checkpoint"))).toBe(true);
       const final = JSON.parse(readFileSync(join(testDir, ".checkpoint"), "utf-8"));
-      expect(final.awaiting).toBe("approve-spec");
+      expect(final.awaiting).toBe("approve-design-choice");
     } finally {
       consoleSpy.mockRestore();
       cleanup();

--- a/src/__tests__/orchestrator/normalize-resume.test.ts
+++ b/src/__tests__/orchestrator/normalize-resume.test.ts
@@ -59,24 +59,24 @@ describe("normalize resume", () => {
     writeFileSync(join(testDir, "original.md"), "# Original PRD");
   });
 
-  it("approve-normalize without feedback proceeds through DESIGN (auto-skip) to SPEC", async () => {
+  it("approve-normalize without feedback proceeds to DESIGN choice checkpoint", async () => {
     const { resumeFromCheckpoint } = await import("../../orchestrator.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    // Resume from approve-normalize → DESIGN auto-skips (no UI keywords) → flows to SPEC checkpoint
+    // Resume from approve-normalize → DESIGN writes approve-design-choice checkpoint
     await resumeFromCheckpoint(
       { awaiting: "approve-normalize", message: "test", timestamp: "2026-03-18T00:00:00Z", feedback: null },
       dirs,
       config,
     );
 
-    // Checkpoint should be approve-spec (DESIGN auto-skipped, no checkpoint written)
+    // Checkpoint should be approve-design-choice (user decides whether to run design)
     expect(existsSync(join(hmDir, ".checkpoint"))).toBe(true);
     const cp = JSON.parse(readFileSync(join(hmDir, ".checkpoint"), "utf-8"));
-    expect(cp.awaiting).toBe("approve-spec");
+    expect(cp.awaiting).toBe("approve-design-choice");
 
     const calls = consoleSpy.mock.calls.map((c) => c[0]);
-    expect(calls.some((c) => typeof c === "string" && c.includes("No UI keywords detected"))).toBe(true);
+    expect(calls.some((c) => typeof c === "string" && c.includes("Awaiting user decision"))).toBe(true);
 
     consoleSpy.mockRestore();
   });

--- a/src/__tests__/stages/design-stage.test.ts
+++ b/src/__tests__/stages/design-stage.test.ts
@@ -754,7 +754,7 @@ interactivity: static
       expect(vi.mocked(appendLogEntry)).toHaveBeenCalled();
     });
 
-    it("does NOT write checkpoint when no UI keywords detected (auto-skip)", async () => {
+    it("writes approve-design-choice checkpoint for user to decide", async () => {
       mkdirSync(join(workingDir, "normalize"), { recursive: true });
       writeFileSync(
         join(workingDir, "normalize", "normalized-prd.md"),
@@ -765,10 +765,13 @@ interactivity: static
 
       await runDesignStage(dirs, config);
 
-      expect(vi.mocked(mockCheckpoint)).not.toHaveBeenCalled();
+      expect(vi.mocked(mockCheckpoint)).toHaveBeenCalledWith(
+        workingDir,
+        expect.objectContaining({ awaiting: "approve-design-choice" }),
+      );
     });
 
-    it("writes approve-design-questionnaire checkpoint when UI keywords detected", async () => {
+    it("writes approve-design-choice checkpoint even when UI keywords present", async () => {
       mkdirSync(join(workingDir, "normalize"), { recursive: true });
       writeFileSync(
         join(workingDir, "normalize", "normalized-prd.md"),
@@ -782,7 +785,7 @@ interactivity: static
       expect(vi.mocked(mockCheckpoint)).toHaveBeenCalledWith(
         workingDir,
         expect.objectContaining({
-          awaiting: "approve-design-questionnaire",
+          awaiting: "approve-design-choice",
         }),
       );
     });
@@ -912,11 +915,11 @@ interactivity: static
 
       // Verify that checkpoint was written with metadata.customMessage
       const calls = vi.mocked(mockCheckpoint).mock.calls;
-      const questionnaireCall = calls.find(
-        (c) => (c[1] as { awaiting: string }).awaiting === "approve-design-questionnaire",
+      const designChoiceCall = calls.find(
+        (c) => (c[1] as { awaiting: string }).awaiting === "approve-design-choice",
       );
-      expect(questionnaireCall).toBeDefined();
-      const checkpoint = questionnaireCall![1] as { metadata?: { customMessage?: string } };
+      expect(designChoiceCall).toBeDefined();
+      const checkpoint = designChoiceCall![1] as { metadata?: { customMessage?: string } };
       expect(checkpoint.metadata).toBeDefined();
       expect(checkpoint.metadata!.customMessage).toBeDefined();
       expect(typeof checkpoint.metadata!.customMessage).toBe("string");

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -165,7 +165,23 @@ export async function runPipeline(
     const hasArtifacts = readdirSync(dirs.workingDir).some(f => !f.startsWith("."));
     if (hasArtifacts) {
       console.log("[cleanup] Removing stale working directory from previous run");
-      rmSync(dirs.workingDir, { recursive: true });
+      try {
+        rmSync(dirs.workingDir, { recursive: true });
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "EBUSY" || code === "EPERM") {
+          // Windows: directory handle still held — rename as fallback (mv works when rm doesn't)
+          const stalePath = `${dirs.workingDir}-stale-${Date.now()}`;
+          console.warn(`[cleanup] rmSync failed (${code}), renaming to ${stalePath}`);
+          try {
+            renameSync(dirs.workingDir, stalePath);
+          } catch {
+            console.warn("[cleanup] Rename also failed — continuing with existing directory");
+          }
+        } else {
+          throw err;
+        }
+      }
     }
   }
 
@@ -407,20 +423,13 @@ export async function resumeFromCheckpoint(
         return;
       }
 
-      // Approved — proceed to DESIGN stage (which gates SPEC)
+      // Approved — proceed to DESIGN stage (which writes approve-design-choice checkpoint)
       const normCostLogPath = join(dirs.workingDir, "cost-log.jsonl");
       const normalizeTracker = CostTracker.loadFromDisk(normCostLogPath, startData.budget);
       await runDesignStage(dirs, config, normalizeTracker);
-
-      // If design auto-skipped (no new checkpoint written), flow directly to SPEC.
-      // The recovery checkpoint (approve-normalize) may still exist — check if design wrote a different one.
-      const postDesignCpPath = join(dirs.workingDir, ".checkpoint");
-      const postDesignCp = existsSync(postDesignCpPath) ? JSON.parse(readFileSafe(postDesignCpPath) ?? "{}") : null;
-      if (!postDesignCp || postDesignCp.awaiting === "approve-normalize") {
-        await runSpecThenCheckpoint(normalizedPrd, dirs, config, silent, startData.stopAfterPlan, startData.greenfield, normalizeTracker);
-      }
       break;
     }
+    case "approve-design-choice":
     case "approve-design-skip": {
       deleteCheckpoint(dirs.workingDir);
       const startDataDesignSkip = getPipelineStartData(dirs.workingDir);

--- a/src/stages/design-stage.ts
+++ b/src/stages/design-stage.ts
@@ -821,48 +821,23 @@ export async function runDesignStage(
   // Log design start
   appendLogEntry(logPath, createLogEntry("DESIGN_START", { reason: "Design stage initiated" }));
 
-  // Step 1: Read normalized PRD and detect UI keywords
+  // Step 1: Ask the user whether this PRD needs UI design
+  // (Replaces faulty auto-detection that matched keywords in "Out of Scope" sections)
   const normalizedPrdPath = join(dirs.workingDir, "normalize", "normalized-prd.md");
   if (!existsSync(normalizedPrdPath)) {
     appendLogEntry(logPath, createLogEntry("DESIGN_SKIPPED", { reason: "No normalized PRD found" }));
-    writeCheckpoint(checkpointDir, {
-      awaiting: "approve-design-skip",
-      message: "No normalized PRD found. Skip design stage?",
-      timestamp: new Date().toISOString(),
-      feedback: null,
-      metadata: { customMessage: "No normalized PRD found — design stage will be skipped." },
-    });
+    console.log("[design] No normalized PRD found — skipping design stage.");
     return;
   }
 
-  const prdContent = readFileSync(normalizedPrdPath, "utf-8");
-  const hasUI = detectUIKeywords(prdContent);
-
-  if (!hasUI) {
-    appendLogEntry(logPath, createLogEntry("DESIGN_SKIPPED", { reason: "No UI keywords detected in PRD" }));
-    console.log("[design] No UI keywords detected — skipping design stage.");
-    return;
-  }
-
-  // Step 2: Generate questionnaire
-  const questionnairePath = await generateQuestionnaire(dirs, config, dirs.workingDir);
-  appendLogEntry(logPath, createLogEntry("DESIGN_QUESTIONNAIRE_COMPLETE", {
-    reason: `Questionnaire generated at ${questionnairePath}`,
-  }));
-
-  // Write checkpoint for user to review/edit the questionnaire
   writeCheckpoint(checkpointDir, {
-    awaiting: "approve-design-questionnaire",
-    message: "Review and edit the design questionnaire, then approve.",
+    awaiting: "approve-design-choice",
+    message: "Does this PRD need UI design? Approve to skip design, reject to run design stage.",
     timestamp: new Date().toISOString(),
     feedback: null,
-    metadata: {
-      customMessage: `Review and edit the design questionnaire at ${questionnairePath}, then approve.`,
-    },
+    metadata: { customMessage: "Does this PRD need UI design? Run: hive-mind approve to skip design and proceed to SPEC, or hive-mind reject --feedback 'needs UI' to run the design stage." },
   });
-
-  // Note: In the actual pipeline, the orchestrator resumes from this checkpoint.
-  // The remaining steps (prototype generation, token extraction) run after
-  // the user approves the questionnaire. For the stage function itself,
-  // we return here and let the orchestrator handle resume flow.
+  console.log("[design] Awaiting user decision: skip or run design stage.");
+  // Orchestrator resumes from approve-design-choice checkpoint.
+  // If user approves (skip) → flow to SPEC. If user rejects → orchestrator generates questionnaire.
 }

--- a/src/state/checkpoint.ts
+++ b/src/state/checkpoint.ts
@@ -69,6 +69,8 @@ export function getCheckpointMessage(type: CheckpointType): string {
       return "Final confirmation. Run: hive-mind approve to complete the pipeline.";
     case "approve-design-skip":
       return "No UI components detected in this PRD. Run: hive-mind approve to skip design and proceed to SPEC, or hive-mind reject --feedback '...' to run the design stage anyway.";
+    case "approve-design-choice":
+      return "Does this PRD need UI design? Run: hive-mind approve to skip design and proceed to SPEC, or hive-mind reject --feedback 'needs UI' to run the design stage.";
     case "approve-design-questionnaire":
       return "Review and edit the design questionnaire at design/design-questionnaire.yaml, then run: hive-mind approve to generate prototype, or hive-mind reject --feedback '...' to regenerate.";
     case "approve-design-prototype":

--- a/src/types/checkpoint.ts
+++ b/src/types/checkpoint.ts
@@ -9,6 +9,7 @@ export type CheckpointType =
   | "verify"
   | "ship"
   | "approve-design-skip"
+  | "approve-design-choice"
   | "approve-design-questionnaire"
   | "approve-design-prototype";
 


### PR DESCRIPTION
## Summary
- **BUG-1**: `detectUIKeywords()` matched "dashboard" in PRD Out of Scope sections, falsely triggering the design stage for backend-only PRDs. Replaced with `approve-design-choice` checkpoint that lets the user decide whether to run design.
- **BUG-2**: `rmSync` on `--force` cleanup crashes with EBUSY on Windows when file handles are held by crashed processes. Added try-catch with `renameSync` fallback (mv works when rm doesn't on Windows).

## Test plan
- [x] `npm run build` exits 0
- [x] `npx tsc --noEmit` exits 0
- [x] `npm run test` — 779/779 passing
- [ ] Run pipeline with backend-only PRD → should get `approve-design-choice` checkpoint (not enter design)
- [ ] Simulate EBUSY by running pipeline, killing it, then `--force` restart → should rename stale dir