### PR TITLE
fix: replace auto UI keyword detection with user-choice design checkpoint

### DIFF
--- a/src/__tests__/e2e/pipeline-smoke.test.ts
+++ b/src/__tests__/e2e/pipeline-smoke.test.ts
@@ -163,16 +163,25 @@ describe("pipeline smoke test (e2e)", () => {
     const logEntries = readLogEntries(hmDir);
     expect(logEntries.some((e) => e.action === "PIPELINE_START")).toBe(true);
 
-    // Step 2: Approve normalize → DESIGN auto-skips (no UI keywords) → checkpoint at approve-spec
+    // Step 2: Approve normalize → DESIGN writes approve-design-skip checkpoint
     await resumeFromCheckpoint(
       { awaiting: "approve-normalize", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
       dirs, config,
     );
 
     cp = readCheckpointFile(hmDir);
-    expect(cp?.awaiting).toBe("approve-spec");
+    expect(cp?.awaiting).toBe("approve-design-skip");
     const logEntries2 = readLogEntries(hmDir);
-    expect(logEntries2.some((e) => e.action === "DESIGN_SKIPPED")).toBe(true);
+    expect(logEntries2.some((e) => e.action === "DESIGN_CHOICE_PENDING")).toBe(true);
+
+    // Step 2b: Approve design-skip → flows to SPEC → checkpoint at approve-spec
+    await resumeFromCheckpoint(
+      { awaiting: "approve-design-skip", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
+      dirs, config,
+    );
+
+    cp = readCheckpointFile(hmDir);
+    expect(cp?.awaiting).toBe("approve-spec");
     expect(existsSync(join(hmDir, "spec"))).toBe(true);
     const logEntries2b = readLogEntries(hmDir);
     expect(logEntries2b.some((e) => e.action === "SPEC_COMPLETE")).toBe(true);
@@ -273,9 +282,18 @@ describe("pipeline smoke test (e2e)", () => {
     let cp = readCheckpointFile(hmDir);
     expect(cp?.awaiting).toBe("approve-normalize");
 
-    // Resume — DESIGN auto-skips (no UI keywords) → SPEC + PLAN run, stopAfterPlan honored → exits with no checkpoint
+    // Resume — DESIGN writes approve-design-skip checkpoint (always asks user now)
     await resumeFromCheckpoint(
       { awaiting: "approve-normalize", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
+      dirs, config,
+    );
+
+    cp = readCheckpointFile(hmDir);
+    expect(cp?.awaiting).toBe("approve-design-skip"); // Design always asks user
+
+    // Approve design-skip → SPEC + PLAN run, stopAfterPlan honored → exits with no checkpoint
+    await resumeFromCheckpoint(
+      { awaiting: "approve-design-skip", message: "", timestamp: "2026-03-18T00:00:00Z", feedback: null },
       dirs, config,
     );
 

--- a/src/__tests__/orchestrator/crash-recovery.test.ts
+++ b/src/__tests__/orchestrator/crash-recovery.test.ts
@@ -120,13 +120,13 @@ describe("crash recovery checkpoints", () => {
         feedback: null,
       };
 
-      // DESIGN stage auto-skips (no UI keywords) → flows to SPEC checkpoint.
+      // DESIGN stage always writes approve-design-skip checkpoint now.
       await resumeFromCheckpoint(checkpoint, dirs, config);
 
-      // Final checkpoint should be approve-spec (DESIGN auto-skipped)
+      // Final checkpoint should be approve-design-skip (design always asks user)
       expect(existsSync(join(testDir, ".checkpoint"))).toBe(true);
       const final = JSON.parse(readFileSync(join(testDir, ".checkpoint"), "utf-8"));
-      expect(final.awaiting).toBe("approve-spec");
+      expect(final.awaiting).toBe("approve-design-skip");
     } finally {
       consoleSpy.mockRestore();
       cleanup();

--- a/src/__tests__/orchestrator/normalize-resume.test.ts
+++ b/src/__tests__/orchestrator/normalize-resume.test.ts
@@ -59,24 +59,24 @@ describe("normalize resume", () => {
     writeFileSync(join(testDir, "original.md"), "# Original PRD");
   });
 
-  it("approve-normalize without feedback proceeds through DESIGN (auto-skip) to SPEC", async () => {
+  it("approve-normalize without feedback proceeds to DESIGN which writes approve-design-skip", async () => {
     const { resumeFromCheckpoint } = await import("../../orchestrator.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    // Resume from approve-normalize → DESIGN auto-skips (no UI keywords) → flows to SPEC checkpoint
+    // Resume from approve-normalize → DESIGN always writes approve-design-skip checkpoint
     await resumeFromCheckpoint(
       { awaiting: "approve-normalize", message: "test", timestamp: "2026-03-18T00:00:00Z", feedback: null },
       dirs,
       config,
     );
 
-    // Checkpoint should be approve-spec (DESIGN auto-skipped, no checkpoint written)
+    // Checkpoint should be approve-design-skip (design always asks user now)
     expect(existsSync(join(hmDir, ".checkpoint"))).toBe(true);
     const cp = JSON.parse(readFileSync(join(hmDir, ".checkpoint"), "utf-8"));
-    expect(cp.awaiting).toBe("approve-spec");
+    expect(cp.awaiting).toBe("approve-design-skip");
 
     const calls = consoleSpy.mock.calls.map((c) => c[0]);
-    expect(calls.some((c) => typeof c === "string" && c.includes("No UI keywords detected"))).toBe(true);
+    expect(calls.some((c) => typeof c === "string" && c.includes("Awaiting user decision"))).toBe(true);
 
     consoleSpy.mockRestore();
   });

--- a/src/__tests__/stages/design-stage.test.ts
+++ b/src/__tests__/stages/design-stage.test.ts
@@ -754,7 +754,7 @@ interactivity: static
       expect(vi.mocked(appendLogEntry)).toHaveBeenCalled();
     });
 
-    it("does NOT write checkpoint when no UI keywords detected (auto-skip)", async () => {
+    it("writes approve-design-skip checkpoint with skip hint when no UI keywords detected", async () => {
       mkdirSync(join(workingDir, "normalize"), { recursive: true });
       writeFileSync(
         join(workingDir, "normalize", "normalized-prd.md"),
@@ -765,10 +765,16 @@ interactivity: static
 
       await runDesignStage(dirs, config);
 
-      expect(vi.mocked(mockCheckpoint)).not.toHaveBeenCalled();
+      expect(vi.mocked(mockCheckpoint)).toHaveBeenCalledWith(
+        workingDir,
+        expect.objectContaining({
+          awaiting: "approve-design-skip",
+          message: expect.stringContaining("No UI keywords detected"),
+        }),
+      );
     });
 
-    it("writes approve-design-questionnaire checkpoint when UI keywords detected", async () => {
+    it("writes approve-design-skip checkpoint with design hint when UI keywords detected", async () => {
       mkdirSync(join(workingDir, "normalize"), { recursive: true });
       writeFileSync(
         join(workingDir, "normalize", "normalized-prd.md"),
@@ -782,7 +788,8 @@ interactivity: static
       expect(vi.mocked(mockCheckpoint)).toHaveBeenCalledWith(
         workingDir,
         expect.objectContaining({
-          awaiting: "approve-design-questionnaire",
+          awaiting: "approve-design-skip",
+          message: expect.stringContaining("UI keywords detected"),
         }),
       );
     });
@@ -910,13 +917,13 @@ interactivity: static
 
       await runDesignStage(dirs, config);
 
-      // Verify that checkpoint was written with metadata.customMessage
+      // Verify that approve-design-skip checkpoint was written with metadata.customMessage
       const calls = vi.mocked(mockCheckpoint).mock.calls;
-      const questionnaireCall = calls.find(
-        (c) => (c[1] as { awaiting: string }).awaiting === "approve-design-questionnaire",
+      const designChoiceCall = calls.find(
+        (c) => (c[1] as { awaiting: string }).awaiting === "approve-design-skip",
       );
-      expect(questionnaireCall).toBeDefined();
-      const checkpoint = questionnaireCall![1] as { metadata?: { customMessage?: string } };
+      expect(designChoiceCall).toBeDefined();
+      const checkpoint = designChoiceCall![1] as { metadata?: { customMessage?: string } };
       expect(checkpoint.metadata).toBeDefined();
       expect(checkpoint.metadata!.customMessage).toBeDefined();
       expect(typeof checkpoint.metadata!.customMessage).toBe("string");

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -426,14 +426,8 @@ export async function resumeFromCheckpoint(
       const normCostLogPath = join(dirs.workingDir, "cost-log.jsonl");
       const normalizeTracker = CostTracker.loadFromDisk(normCostLogPath, startData.budget);
       await runDesignStage(dirs, config, normalizeTracker);
-
-      // If design auto-skipped (no new checkpoint written), flow directly to SPEC.
-      // The recovery checkpoint (approve-normalize) may still exist — check if design wrote a different one.
-      const postDesignCpPath = join(dirs.workingDir, ".checkpoint");
-      const postDesignCp = existsSync(postDesignCpPath) ? JSON.parse(readFileSafe(postDesignCpPath) ?? "{}") : null;
-      if (!postDesignCp || postDesignCp.awaiting === "approve-normalize") {
-        await runSpecThenCheckpoint(normalizedPrd, dirs, config, silent, startData.stopAfterPlan, startData.greenfield, normalizeTracker);
-      }
+      // Design stage always writes a checkpoint (approve-design-skip or approve-design-questionnaire).
+      // Orchestrator waits for the user to approve/reject before proceeding.
       break;
     }
     case "approve-design-skip": {

--- a/src/stages/design-stage.ts
+++ b/src/stages/design-stage.ts
@@ -848,14 +848,27 @@ export async function runDesignStage(
 
   const prdContent = readFileSync(normalizedPrdPath, "utf-8");
   const hasUI = detectUIKeywords(prdContent);
+  const detectedKeywords = UI_KEYWORDS.filter((kw) => {
+    const pattern = new RegExp(`\\b${kw.replace(/\s+/g, "\\s+")}\\b`, "i");
+    return pattern.test(prdContent);
+  });
 
-  if (!hasUI) {
-    appendLogEntry(logPath, createLogEntry("DESIGN_SKIPPED", { reason: "No UI keywords detected in PRD" }));
-    console.log("[design] No UI keywords detected — skipping design stage.");
-    return;
-  }
+  // Always ask the user whether design is needed (keyword detection is a hint, not a gate)
+  const hint = hasUI
+    ? `UI keywords detected: ${detectedKeywords.join(", ")} — design recommended`
+    : "No UI keywords detected — skip recommended";
+  appendLogEntry(logPath, createLogEntry("DESIGN_CHOICE_PENDING", { reason: hint }));
+  writeCheckpoint(checkpointDir, {
+    awaiting: "approve-design-skip",
+    message: hint,
+    timestamp: new Date().toISOString(),
+    feedback: null,
+    metadata: { customMessage: `${hint}. Approve to skip design, or reject with feedback to enter design flow.`, detectedKeywords },
+  });
+  console.log(`[design] ${hint}. Awaiting user decision.`);
+  return;
 
-  // Step 2: Generate questionnaire
+  // Step 2: Generate questionnaire (reached only via approve-design-skip rejection in orchestrator)
   const questionnairePath = await generateQuestionnaire(dirs, config, dirs.workingDir);
   appendLogEntry(logPath, createLogEntry("DESIGN_QUESTIONNAIRE_COMPLETE", {
     reason: `Questionnaire generated at ${questionnairePath}`,

--- a/src/types/manager-log.ts
+++ b/src/types/manager-log.ts
@@ -37,7 +37,8 @@ export type LogAction =
   | "DESIGN_START"
   | "DESIGN_QUESTIONNAIRE_COMPLETE"
   | "DESIGN_PROTOTYPE_APPROVED"
-  | "DESIGN_SKIPPED";
+  | "DESIGN_SKIPPED"
+  | "DESIGN_CHOICE_PENDING";
 
 export interface ManagerLogEntry {
   timestamp: string;


### PR DESCRIPTION
## Summary
- `detectUIKeywords()` matched "dashboard" in PRD Out of Scope sections, falsely triggering the design stage for backend-only PRDs (Run 5 BUG-1)
- Replace silent auto-skip with `approve-design-skip` checkpoint that always asks user/agent whether design is needed
- Keyword detection kept as hint in checkpoint message, not as a gate

## Changes
- `src/stages/design-stage.ts` — always write `approve-design-skip` checkpoint with keyword hint
- `src/orchestrator.ts` — remove post-design auto-flow-to-SPEC logic
- `src/types/manager-log.ts` — add `DESIGN_CHOICE_PENDING` log action
- 4 test files updated to match new checkpoint flow

## Test plan
- [x] `npm run build` exits 0
- [x] `npx tsc --noEmit` exits 0
- [x] `npm run test` — 767/767 passing
- [ ] Run pipeline with backend-only PRD — should get `approve-design-skip` (not enter design)
- [ ] Run pipeline with UI PRD — should get `approve-design-skip` with "design recommended" hint