### PR TITLE
fix: dashboard hang after checkpoint, design-skip warning, double output detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -375,13 +375,10 @@ export async function main(): Promise<void> {
   }
   } finally {
     if (dashboardHandle) {
-      // If pipeline is paused at checkpoint, keep dashboard alive — its HTTP server
-      // keeps the event loop running so the process stays up until next command.
-      const checkpointExists = fileExists(join(dirs.workingDir, ".checkpoint"));
-      if (!checkpointExists) {
-        dashboardHandle.signalShutdown(Date.now() + 60_000);
-        setTimeout(() => dashboardHandle!.stop(), 60_000);
-      }
+      // Always shut down dashboard so the process can exit and release the PID lock.
+      // The next command (approve/reject) will start its own dashboard instance.
+      dashboardHandle.signalShutdown(Date.now() + 5_000);
+      setTimeout(() => dashboardHandle!.stop(), 5_000);
     }
   }
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -457,6 +457,9 @@ export async function resumeFromCheckpoint(
         notifyCheckpoint(silent, getCheckpointMessage("approve-design-questionnaire"));
       } else {
         // Approved skip — proceed directly to SPEC
+        appendLogEntry(join(dirs.workingDir, "manager-log.jsonl"), createLogEntry("DESIGN_SKIPPED", {
+          reason: "User approved design skip",
+        }));
         const skipCostLogPath = join(dirs.workingDir, "cost-log.jsonl");
         const skipTracker = CostTracker.loadFromDisk(skipCostLogPath, startDataDesignSkip.budget);
         const normalizedPrdSkip = join(dirs.workingDir, "normalize", "normalized-prd.md");

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -145,9 +145,10 @@ export function spawnClaude(options: ClaudeSpawnOptions): Promise<ClaudeSpawnRes
     if (options.outputFile) {
       const interval = options.outputPollIntervalMs ?? 5000;
       pollTimer = setInterval(() => {
-        if (existsSync(options.outputFile!)) {
+        if (!killedByOutputDetection && existsSync(options.outputFile!)) {
           killedByOutputDetection = true;
           console.debug(`[spawnClaude] Output file detected, terminating process early: ${options.outputFile}`);
+          clearInterval(pollTimer);
           child.kill("SIGTERM");
         }
       }, interval);


### PR DESCRIPTION
## Summary

Three bugs discovered during Run 6 dog-food pipeline:

- **Dashboard keeps process alive after checkpoint**: The `finally` block in `main()` intentionally kept the dashboard HTTP server alive when a checkpoint existed, preventing the Node process from exiting. This conflicted with the PID lock from v0.23.1 — `approve` couldn't run because `start` was still holding the lock. Fix: always shut down dashboard with 5s grace period so the process can exit.
- **Misleading design-skip warning**: When user approves `approve-design-skip`, no `DESIGN_SKIPPED` entry was written to the manager log. The SPEC stage then saw `DESIGN_START` without `DESIGN_SKIPPED` and warned "Design stage ran but produced no artifacts". Fix: log `DESIGN_SKIPPED` before proceeding to SPEC.
- **Double output file detection**: The `setInterval` poll in `spawnClaude` didn't stop after first detection; `clearInterval` only ran in the `close` handler. If the child process took >5s to die after SIGTERM, the poll fired again. Fix: guard with `killedByOutputDetection` flag and `clearInterval` immediately on first detection.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (767/767)
- [ ] Manual: `start` exits after normalize checkpoint — `approve` acquires lock without error
- [ ] Manual: approve design-skip — SPEC shows no "Design stage ran" warning
- [ ] Manual: single `[spawnClaude] Output file detected` log line per agent