### PR TITLE
docs: integrate 5 harness improvement ideas into roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,14 @@ TypeScript ESM project. npm-publishable CLI tool.
 - Check for renamed types/exports via Grep before importing in test files
 - Run `npx tsc --noEmit` after writing tests to catch mismatches before `npm test`
 
+## Agent Prompt Architecture (Hybrid Model)
+- Agent identity (ROLE, RULES, few-shot examples) lives in `.claude/skills/` SKILL.md files
+- Dynamic context (INPUT, OUTPUT, MEMORY, CONSTITUTION, ROLE REPORTS) stays in `buildPrompt()` in `src/agents/prompts.ts`
+- `AGENT_REGISTRY` in `src/agents/registry.ts` is the single source of truth for agent metadata
+- Skills are generated from registry via `src/skills/builder.ts` (not hand-maintained)
+- Pipeline injects skills into target project via `src/skills/installer.ts` at pipeline start
+- ~21 Tier 1 agents convert to skills; ~15 Tier 3 agents (empty rules, JSON output) stay as code
+- See `docs/harness-roadmap/roadmap-releases.md` Pre-R2 + R2 for implementation timeline
+
 ## Diagnostic Logs
 - `.hive-mind-dashboard.log` (project root) — dashboard lifecycle events (DASHBOARD_START, DASHBOARD_STOP, DASHBOARD_SHUTDOWN, DASHBOARD_DECISION, DASHBOARD_REUSE, BROWSER_OPEN, BROWSER_SKIP, BROWSER_MARKER_WRITTEN)

--- a/docs/harness-roadmap/roadmap-backlog.md
+++ b/docs/harness-roadmap/roadmap-backlog.md
@@ -10,8 +10,8 @@ Release targets: `[R2]`, `[R3]`, `[post-R1]` etc. Omit if not yet triaged.
 
 ## Backlog Items
 
-- BL-001 [P5] One PR per story in pipeline -- each story gets own branch/PR instead of one big branch (candidate for R2)
-- BL-002 [P4] Evaluate which stages/prompts should be skills -- audit during R2 planning: Normalize (73 lines, 1 agent) is a strong candidate for full skill conversion; Spec/Plan too complex (orchestration logic) but their prompt text can be extracted into skills. Deferred to R2.
+- BL-001 [P5] [R2] **RESOLVED** One PR per story in pipeline -- new `execute-ship.ts` stage with `shipMode: "pr-per-story"`. Per story: branch, commit, push, PR, CI poll. No self-review (2 review layers sufficient). PRs left open; squash-merge all at final `ship` checkpoint. Resolved 2026-03-31.
+- BL-002 [P4] [Pre-R2/R2] **RESOLVED** Evaluate which stages/prompts should be skills -- confirmed hybrid prompt model: static identity (ROLE, RULES, few-shot) in SKILL.md files, dynamic context (INPUT, OUTPUT, MEMORY) in `buildPrompt()`. `AGENT_REGISTRY` remains single source of truth; skills are generated via `generateSkills()` build step. ~21 Tier 1 agents convert in R2. Skill packaging (Pre-R2) is prerequisite. Resolved 2026-03-31.
 - BL-003 [P4] 3-tier memory model: persistent (brand voice, SOP), per-session (user query, chat history), searchable (knowledge-base, vector DB) -- aligns with R3 memory items (SQL DB, Claude-Mem)
 - BL-004 [P6] Cost breakdown by agent and model type in pipeline run -- extend CostTracker to track model field per AgentCostEntry (candidate for R2)
 - BL-005 [P2] Dashboard visible from Normalize stage -- show stage progress from pipeline start, not just EXECUTE; use frontend design skill for UI (candidate for R2)

--- a/docs/harness-roadmap/roadmap-releases.md
+++ b/docs/harness-roadmap/roadmap-releases.md
@@ -43,11 +43,38 @@
 
 ---
 
+## Pre-R2: "Wire the Skills"
+
+**Theme:** Prerequisite infrastructure for R2's skill-based architecture.
+
+**Timeline:** 1 week (between R1 completion and R2 start)
+
+**What ships:**
+| # | Item | Effort | Ref |
+|---|---|---|---|
+| 1 | Bundle pipeline skills in npm package + runtime injection | Small | BL-002 |
+
+**Details:**
+- Add `skills/` directory to hive-mind repo with pipeline `.md` files + `manifest.json`
+- Implement `ensurePipelineSkills(projectRoot)` in `src/skills/installer.ts`
+- Called at pipeline start: copies skills into `{projectRoot}/.claude/skills/` with `hive-mind-` prefix
+- Version-tracked via `.hive-mind-skills-version` marker file
+- Bundled: skeptical-critic, skeptical-evaluator, skeptical-code-reviewer, compliance-ec-rules, future generated agent skills
+- NOT bundled: user-facing skills (ship, prd, mailbox, etc.)
+
+**Exit criteria:**
+- `npm pack` includes `skills/` directory with all pipeline skill `.md` files
+- `ensurePipelineSkills()` copies skills to target project's `.claude/skills/` at pipeline start
+- Skill version marker tracks which hive-mind version installed the skills
+- Existing pipeline behavior unchanged (backward compatible)
+
+---
+
 ## Release 2: "Sharpen the Loop"
 
-**Theme:** Make the GAN loop cheaper, smarter, and safer.
+**Theme:** Make the GAN loop cheaper, smarter, and safer. Migrate agent prompts to skills.
 
-**Timeline:** 2-3 weeks (after R1)
+**Timeline:** 2-3 weeks (after Pre-R2)
 
 **Candidate items:**
 | # | Item | Pillar | Effort | Ref |
@@ -59,14 +86,25 @@
 | 5 | Memory summarization between waves | P4 | Small | P4 ss4.1 |
 | 6 | Multi-dimensional scorecard with rubric | P3 | Medium | P3 ss3.3 |
 | 7 | Command blocklist + path-scoped writes | P6 | Small | P6 ss6.4 |
+| 8 | Hybrid prompt model: prompts → skills | P4 | Medium | BL-002 |
+| 9 | Ship stage: per-story branch/PR/CI | P6 | Medium | BL-001 |
+| 10 | Skill run data recording (pipeline agents) | P4 | Small | -- |
 
-**Why second:** Reduces cost per pipeline run by 30-50%. Quality improvements compound with every run after this.
+**Why second:** Reduces cost per pipeline run by 30-50%. Quality improvements compound with every run after this. Skill migration makes agent behavior editable and measurable.
+
+**New items explained:**
+- **Item 8 (Hybrid prompt model):** Split agent prompts into static identity (SKILL.md files generated from `AGENT_REGISTRY`) and dynamic context (`buildPrompt()` handles INPUT, OUTPUT, MEMORY only). ~21 Tier 1 agents convert incrementally via `SKILL_AGENTS` gate in `prompts.ts`. Registry remains single source of truth; skills are derived via `generateSkills()` build step.
+- **Item 9 (Ship stage):** New `execute-ship.ts` replaces `execute-commit.ts` when `shipMode: "pr-per-story"`. Per story: branch, commit, push, PR, CI poll. No self-review (VERIFY + REPORT code-reviewer = 2 layers sufficient). PRs left open; squash-merge all at final `ship` checkpoint.
+- **Item 10 (Skill run data):** Instrument `spawnAgent()` to record which skills were loaded per agent run. Write to `skill-run-log.jsonl`. REPORT stage generates `skill-effectiveness.md`. Cross-run history accumulates in `{knowledgeDir}/skill-run-history.jsonl` for R3's SELF-IMPROVE.
 
 **Exit criteria:** (to be detailed when R1 nears completion)
 - VERIFY only re-tests failed ACs/ECs on retry
 - Hooks provide tsc/lint feedback during BUILD without separate agent
 - Scorecard grades 7 dimensions with weighted rubric
 - Memory.md summarized between waves
+- ~21 agent types have SKILL.md files generated from registry
+- `shipMode: "pr-per-story"` produces per-story PRs with CI validation
+- `skill-run-log.jsonl` captures skills loaded, duration, cost, and success per agent run
 
 ---
 
@@ -133,6 +171,6 @@
 
 ## Deferred (v2+)
 Items explicitly deferred beyond R4:
-- **Full RAG + SQL memory with embeddings (P4)** -- LLM-driven consolidation (R3) gets 80% of value without vector infra
+- **RAG standalone MCP server (P4)** -- Build as standalone project (SP-008) after R1. Integrate into pipeline in R3 via `mcpServers` config. See [roadmap-standalone-projects.md](roadmap-standalone-projects.md) SP-008.
 - **MCP Phase 2: expose Hive Mind as MCP server (P1)** -- no demand yet; build consumer side first (R1), expose when orchestration layer needs it
 - **NotebookLLM-py integration (P6)** -- unofficial API using undocumented Google endpoints, zero production reliability

--- a/docs/harness-roadmap/roadmap-standalone-projects.md
+++ b/docs/harness-roadmap/roadmap-standalone-projects.md
@@ -50,6 +50,21 @@ SP-NNN | Type | One-line description
 **Description:** Create a demo video of current hive-mind capabilities using the Remotion skill (SP-001). Do this before R1 harness improvements to showcase the baseline product.
 **Depends on:** SP-001
 
+### SP-008: RAG MCP Server
+**Type:** Standalone MCP server (separate repo)
+**Description:** Reusable semantic search over markdown knowledge bases. Any Claude Code session can use it via `mcpServers` config. Ingests documents into sqlite-vec vector store, provides semantic search with collection/filter scoping. MVP: `rag_ingest` (add docs) + `rag_search` (query) tools, markdown-aware chunking, sqlite-vec storage (zero external deps).
+**Timeline:** Build after R1 (needs MCP Phase 1 for integration path). Integrate into hive-mind pipeline in R3 by replacing static KB reads with `rag_search` calls.
+**Architecture:**
+```
+@hive-mind/rag-server
+  src/server.ts            -- MCP entry point
+  src/tools/ingest.ts      -- rag_ingest tool
+  src/tools/search.ts      -- rag_search tool
+  src/pipeline/chunker.ts  -- markdown-aware splitting
+  src/pipeline/embedder.ts -- embedding API calls
+  src/store/sqlite-vec.ts  -- SQLite + sqlite-vec
+```
+
 ---
 
 ## How to Use This List


### PR DESCRIPTION
## Summary
- Add **Pre-R2** section to roadmap: skill packaging (bundle pipeline skills in npm, inject at runtime)
- Expand **R2** with 3 new items: hybrid prompt model (~21 agents), ship stage (per-story PRs), skill run data recording
- Resolve **BL-001** (ship stage) and **BL-002** (hybrid model) in backlog
- Add **SP-008** (RAG MCP server) to standalone projects
- Add **Agent Prompt Architecture (Hybrid Model)** convention to CLAUDE.md
- Update Deferred section: RAG moved from v2+ to SP-008

## Context
Five ideas discussed and planned in session: prompts-to-skills, per-story shipping, skill packaging, skill run data, and RAG as standalone MCP server. Companion PR in ai-brain: ziyilam3999/ai-brain#126.

## Test plan
- [ ] roadmap-releases.md: Pre-R2 and R2 sections are consistent with each other
- [ ] roadmap-backlog.md: BL-001 and BL-002 marked resolved with correct release targets
- [ ] roadmap-standalone-projects.md: SP-008 follows existing format
- [ ] CLAUDE.md: Hybrid model section is accurate and discoverable
- [ ] No timeline conflicts across roadmap files